### PR TITLE
chore: add FUNDING.yml for GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: theaiagent


### PR DESCRIPTION
## Summary
Adds `.github/FUNDING.yml` pointing to the active GitHub Sponsors profile at https://github.com/sponsors/theaiagent

This enables the "Sponsor" button on the repository page.

## Test plan
- [x] Single-line config file, no code changes