### PR TITLE
fix: add grade floor to close GPA calibration gap (8.6% → 3.3%)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,81 @@
+# SynthEd — Project Instructions
+
+> For project history, decisions, and context see [MEMORY.md](MEMORY.md)
+
+## Quick Start
+
+```bash
+pip install -e ".[dev]"              # Dev install
+python run_pipeline.py               # Default: 200 students, 14 weeks
+python run_pipeline.py --n 500       # Custom population
+python run_pipeline.py --llm         # LLM backstory enrichment (needs OPENAI_API_KEY)
+```
+
+```python
+from synthed.pipeline import SynthEdPipeline
+pipeline = SynthEdPipeline(output_dir="./output", seed=42)
+report = pipeline.run(n_students=200)
+
+# Multi-semester
+pipeline = SynthEdPipeline(output_dir="./output", seed=42, n_semesters=4)
+report = pipeline.run(n_students=200)
+```
+
+## Before Every Commit
+
+```bash
+ruff check synthed/ tests/ --select E,F,W --ignore E501
+python -m pytest tests/ -q --tb=short
+```
+
+Both must pass before committing. No exceptions.
+
+## Key Rules
+
+- **Immutability**: Never mutate `StudentPersona`. Use `dataclasses.replace()`. SimulationState mutation is OK.
+- **Theory modules**: Stateless classes, `_UPPERCASE` named constants. Follow `academic_exhaustion.py` pattern.
+- **Imports**: Use `TYPE_CHECKING` to avoid circular imports in theory modules.
+- **Version**: Auto-derived from git tags via `setuptools-scm`. Never hardcode.
+- **Logging**: `logging.getLogger(__name__)`, never `print()`.
+- **File size**: Max 800 lines. Extract if approaching.
+- **Commits**: No severity labels (HIGH/MEDIUM/LOW) in commit messages or release notes.
+- **Co-Authored-By**: All commits include `Co-Authored-By: Claude <81847+claude@users.noreply.github.com>`
+- **Zenodo metadata**: `.zenodo.json` and `CITATION.cff` must exist in repo root with correct ORCID IDs and affiliations. Update if authors or affiliations change. After each release, manually set Programming Language=Python and Development Status=Active on Zenodo (these fields are not supported by `.zenodo.json`).
+- **Release notes format**: Every GitHub release must start with the standard SynthEd description paragraph, then Authors with ORCID links, then What's New / What's Changed / Quality sections. Update `.zenodo.json` description with "Latest Release" changelog BEFORE creating git tag.
+- **Branch workflow**: All changes via feature branches + PRs. No direct main commits. CI must pass before merge.
+
+## Architecture
+
+```
+synthed/
+├── agents/           # Persona + factory (population generation)
+├── simulation/
+│   ├── engine.py     # Orchestrator (delegates to theories/)
+│   ├── theories/     # 11 modules, one per theoretical framework
+│   ├── semester.py   # Multi-semester with carry-over
+│   └── social_network.py  # Peer network (degree cap, link decay)
+├── validation/       # 21 statistical tests (5 levels)
+├── analysis/         # Sobol (SALib), Optuna calibrator, OULAD validator, auto_bounds, OAT
+├── benchmarks/       # 4 institutional profiles
+├── data_output/      # CSV export + OULAD 7-table export
+├── utils/            # LLM wrapper, logging, validation helpers
+└── pipeline.py       # End-to-end orchestrator
+```
+
+## Environment
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `OPENAI_API_KEY` | Only with `--llm` | LLM backstory enrichment |
+
+## Gotchas
+
+- **Windows CRLF**: Git warnings normal, harmless
+- **PersonaConfig validation**: Distributions must sum to 1.0
+- **Rate limits**: LLM enrichment degrades gracefully (empty backstory)
+- **Multi-semester RNG**: 4-semester ≠ 4× single-semester (RNG carries forward)
+- **students.csv = initial values**: Final values in outcomes.csv
+- **Engagement history**: Recorded AFTER peer influence (Phase 2)
+- **Student IDs non-deterministic**: UUIDv7 embeds wall-clock time. Same seed at different times → different IDs. Simulation state is deterministic, IDs are not.
+- **Calibration data staleness**: `CALIBRATION_DATA` in calibration.py was re-measured 2026-04-01 post grade-floor addition (N=500, 5 seeds). Re-measure if theory modules, engine weights, or RNG-consuming code paths change.
+- **Grade floor**: `engine._GRADE_FLOOR=0.45` models baseline marks from templates, partial credit, and easy portions. Adjusting this shifts the entire GPA distribution — re-calibrate after changes.

--- a/synthed/analysis/sobol_sensitivity.py
+++ b/synthed/analysis/sobol_sensitivity.py
@@ -139,6 +139,7 @@ SOBOL_PARAMETER_SPACE: tuple[SobolParameter, ...] = (
     SobolParameter("engine._EXAM_ENG_WEIGHT", 0.05, 0.35, "Engagement → exam quality"),
     SobolParameter("engine._EXAM_EFFICACY_WEIGHT", 0.05, 0.35, "Self-efficacy → exam quality"),
     SobolParameter("engine._ASSIGN_SUBMIT_BASE", 0.15, 0.50, "Base assignment submission probability"),
+    SobolParameter("engine._GRADE_FLOOR", 0.30, 0.55, "Structural grade floor (partial credit)"),
 )
 
 

--- a/synthed/analysis/trait_calibrator.py
+++ b/synthed/analysis/trait_calibrator.py
@@ -69,8 +69,8 @@ class CalibrationResult:
 # Calibrator
 # ─────────────────────────────────────────────
 
-_DROPOUT_WEIGHT: float = 0.50    # dropout rate match priority
-_GPA_WEIGHT: float = 0.30       # GPA distribution match
+_DROPOUT_WEIGHT: float = 0.40    # dropout rate match priority
+_GPA_WEIGHT: float = 0.40       # GPA distribution match
 _ENGAGEMENT_WEIGHT: float = 0.20  # engagement level match
 
 

--- a/synthed/calibration.py
+++ b/synthed/calibration.py
@@ -37,25 +37,25 @@ class CalibrationEstimate:
 
 
 # Empirically measured calibration data (N=500, 5 seeds averaged per point).
-# Measured 2026-03-31 post disability_severity (Rovai accessibility + B&M pressure).
+# Measured 2026-04-01 post grade-floor addition (engine._GRADE_FLOOR = 0.45).
 # IMPORTANT: Re-measure if theory modules, engine weights, or RNG-consuming
 #            code paths change (even non-dropout features shift RNG sequence).
 # TODO: Warn when n_students is small (e.g. <100) — stochastic variance
 #       makes calibration estimates unreliable at low N.
 CALIBRATION_DATA: tuple[CalibrationPoint, ...] = (
     # 1-semester sweep across dropout_base_rate values
-    CalibrationPoint(1, 0.20, 0.207, 500, 5),
-    CalibrationPoint(1, 0.30, 0.276, 500, 5),
-    CalibrationPoint(1, 0.40, 0.319, 500, 5),
-    CalibrationPoint(1, 0.50, 0.347, 500, 5),
-    CalibrationPoint(1, 0.60, 0.384, 500, 5),
-    CalibrationPoint(1, 0.70, 0.431, 500, 5),
-    CalibrationPoint(1, 0.80, 0.446, 500, 5),
-    CalibrationPoint(1, 0.90, 0.462, 500, 5),
-    CalibrationPoint(1, 0.95, 0.462, 500, 5),
+    CalibrationPoint(1, 0.20, 0.189, 500, 5),
+    CalibrationPoint(1, 0.30, 0.259, 500, 5),
+    CalibrationPoint(1, 0.40, 0.317, 500, 5),
+    CalibrationPoint(1, 0.50, 0.350, 500, 5),
+    CalibrationPoint(1, 0.60, 0.363, 500, 5),
+    CalibrationPoint(1, 0.70, 0.402, 500, 5),
+    CalibrationPoint(1, 0.80, 0.414, 500, 5),
+    CalibrationPoint(1, 0.90, 0.436, 500, 5),
+    CalibrationPoint(1, 0.95, 0.445, 500, 5),
     # Multi-semester at default rate (0.80)
-    CalibrationPoint(2, 0.80, 0.718, 500, 5),
-    CalibrationPoint(4, 0.80, 0.939, 500, 5),
+    CalibrationPoint(2, 0.80, 0.690, 500, 5),
+    CalibrationPoint(4, 0.80, 0.917, 500, 5),
 )
 
 # Bounds for dropout_base_rate

--- a/synthed/simulation/engine.py
+++ b/synthed/simulation/engine.py
@@ -154,6 +154,7 @@ class SimulationEngine:
     _ASSIGN_NOISE_WEIGHT: float = 0.15        # random noise weight in quality
     _ASSIGN_NOISE_STD: float = 0.15           # std dev of assignment quality noise
     _GPA_SCALE: float = 4.0                   # GPA denominator for normalisation
+    _GRADE_FLOOR: float = 0.45               # structural grade floor (easy marks, partial credit)
     _MISSED_IMPACT: float = -0.3              # memory impact of missed assignment
 
     # Live sessions
@@ -342,8 +343,14 @@ class SimulationEngine:
         return all_records, states, self.network
 
     def _record_graded_item(self, state: SimulationState, quality: float) -> None:
-        """Update cumulative GPA with a graded item (assignment or exam)."""
-        state.gpa_points_sum += quality * self._GPA_SCALE
+        """Update cumulative GPA with a graded item (assignment or exam).
+
+        Applies a structural grade floor before scaling to GPA. In real courses
+        students earn baseline marks from assignment templates, partial credit,
+        and easy initial portions — this floor captures that effect.
+        """
+        graded = self._GRADE_FLOOR + (1.0 - self._GRADE_FLOOR) * quality
+        state.gpa_points_sum += graded * self._GPA_SCALE
         state.gpa_count += 1
         state.cumulative_gpa = state.gpa_points_sum / state.gpa_count
 

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -17,14 +17,14 @@ class TestCalibrationMap:
 
     def test_estimate_known_point(self):
         """Estimation at a known observed dropout should return its base_rate."""
-        # 1-sem, rate=0.60, observed=0.384
-        result = self.cal.estimate(0.384, n_semesters=1)
+        # 1-sem, rate=0.60, observed=0.363
+        result = self.cal.estimate(0.363, n_semesters=1)
         assert abs(result.estimated_dropout_base_rate - 0.60) < 0.05
 
     def test_estimate_interpolation(self):
         """Interpolated value should be between neighboring known points."""
-        result = self.cal.estimate(0.35, n_semesters=1)
-        # 0.319 -> 0.40, 0.347 -> 0.50, so 0.35 should give ~0.40-0.55
+        result = self.cal.estimate(0.34, n_semesters=1)
+        # 0.317 -> 0.40, 0.350 -> 0.50, so 0.34 should give ~0.40-0.55
         assert 0.35 <= result.estimated_dropout_base_rate <= 0.55
         assert result.confidence == "high"
 


### PR DESCRIPTION
## Summary

- Add structural grade floor (`_GRADE_FLOOR=0.45`) to `_record_graded_item` — models baseline marks from templates, partial credit, and easy assignment portions that real students earn
- Rebalance Optuna loss weights (dropout 0.50→0.40, GPA 0.30→0.40) so calibration prioritizes GPA equally with dropout
- Re-measure `CALIBRATION_DATA` with N=500, 5 seeds post grade-floor
- Add `_GRADE_FLOOR` to Sobol parameter space for sensitivity analysis

### Results (N=500, 80-trial Optuna)

| Metric | Before (v0.6.3) | After |
|--------|-----------------|-------|
| GPA error | 8.6% (2.77 vs 3.03) | **3.3% (2.93 vs 3.03)** |
| Dropout error | — | 6.3% (0.29 vs 0.31) |
| Composite loss | 0.0036 | **0.0022** |

### Root cause

Two-agent cross-examination (forward tracer + reverse analyst) identified a structural mismatch: the quality formula centers output at ~0.50, but OULAD scores average 75.8/100 (GPA 3.03). In real courses, students earn baseline marks from course structure — this floor was missing from the model.

## Test plan

- [x] 472 tests pass, lint clean
- [x] N=500, 5-seed validation confirms GPA improvement
- [x] CALIBRATION_DATA re-measured with new engine
- [x] Sobol parameter space updated