### PR TITLE
docs: update README, GUIDE, THEORY for benchmark reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@
 - **Adaptive Parameter Bounds** -- `auto_bounds()` adjusts calibration space when demographics change
 - **5-Level Validation Suite** -- 21 statistical tests (distributions, correlations, temporal coherence, privacy, backstory)
 - **Optional LLM Enrichment** -- Persona-grounded narrative backstories via OpenAI, Ollama, or any compatible provider
-- **472 Tests** -- 98% coverage, CI across Python 3.10/3.11/3.12
+- **4 Benchmark Profiles** -- Developing, Western, Corporate, Mega University with CLI report generation
+- **477 Tests** -- 98% coverage, CI across Python 3.10/3.11/3.12
 
 ---
 
@@ -48,6 +49,7 @@ pip install -e ".[dev]"
 python run_pipeline.py              # 200 students, 14 weeks
 python run_pipeline.py --n 500      # Custom population
 python run_pipeline.py --oulad      # OULAD-compatible export
+python run_pipeline.py --benchmark  # Run all 4 benchmark profiles
 ```
 
 ```python
@@ -82,6 +84,7 @@ print(f"Dropout: {report['simulation_summary']['dropout_rate']:.1%}")
 - [x] Multi-semester simulation with carry-over
 - [x] 11 theory modules (Tinto, Bean & Metzner, Kember, SDT, Garrison, Moore, Rovai, Baulke, Epstein & Axtell, Gonzalez, Unavoidable Withdrawal)
 - [x] Trait-based calibration (Sobol + Optuna + OULAD validation)
+- [x] Benchmark reports with CLI (`--benchmark`)
 - [x] OULAD-compatible 7-table export
 - [x] LLM enrichment with cost control and streaming
 - [x] Disability severity (Beta distribution)

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -144,11 +144,11 @@ pipeline = SynthEdPipeline(
 report = pipeline.run(n_students=300)
 ```
 
-| Semesters | Default Dropout Rate | Quality |
-|-----------|---------------------|---------|
-| 1 (14 weeks) | ~46% | A (Excellent) |
-| 2 (28 weeks) | ~76% | B (Good) |
-| 4 (56 weeks) | ~96% | B (Good) |
+| Semesters | Default Dropout Rate (base=0.80) | Quality |
+|-----------|----------------------------------|---------|
+| 1 (14 weeks) | ~41% | A (Excellent) |
+| 2 (28 weeks) | ~69% | B (Good) |
+| 4 (56 weeks) | ~92% | B (Good) |
 
 ---
 
@@ -180,19 +180,31 @@ report = pipeline.run(n_students=300)
 
 ## 🏛️ Benchmark Profiles
 
-Pre-defined institutional contexts:
+Pre-defined institutional contexts with CLI support:
+
+```bash
+python run_pipeline.py --benchmark                                     # All 4 profiles + comparison report
+python run_pipeline.py --benchmark --benchmark-profile mega_university # Single profile
+```
 
 ```python
+from synthed.pipeline import SynthEdPipeline
+
 pipeline = SynthEdPipeline.from_profile("high_dropout_developing")
 report = pipeline.run(n_students=500)
+
+# Generate comparison report for all profiles
+from synthed.benchmarks.generator import BenchmarkGenerator
+gen = BenchmarkGenerator()
+md = gen.generate_report(output_dir="./benchmarks")  # writes benchmark_report.md + benchmark_results.json
 ```
 
 | Profile | Scenario | Expected Dropout |
 |---------|----------|-----------------|
-| `high_dropout_developing` | Developing country ODL | 60-90% |
-| `moderate_dropout_western` | Western university | 30-60% |
-| `low_dropout_corporate` | Corporate training | 5-30% |
-| `mega_university` | Mega university | 55-85% |
+| `high_dropout_developing` | Developing country ODL | 50-66% |
+| `moderate_dropout_western` | Western university | 15-35% |
+| `low_dropout_corporate` | Corporate training | 5-25% |
+| `mega_university` | Mega university | 35-55% |
 
 ---
 

--- a/docs/THEORY.md
+++ b/docs/THEORY.md
@@ -151,7 +151,7 @@ SynthEd/
 │   │   └── _sim_runner.py       # Shared simulation runner
 │   ├── benchmarks/
 │   │   ├── profiles.py          # 4 institutional profiles
-│   │   └── generator.py         # Benchmark dataset generator
+│   │   └── generator.py         # Benchmark dataset generator + report
 │   ├── utils/
 │   │   ├── llm.py               # OpenAI wrapper with cache, cost, streaming
 │   │   ├── llm_memory.py        # Immutable ConversationMemory
@@ -159,7 +159,7 @@ SynthEd/
 │   │   └── validation.py        # Input validation utilities
 │   ├── calibration.py           # CalibrationMap: target dropout -> params
 │   └── pipeline.py              # End-to-end orchestrator
-├── tests/                       # 472 pytest tests across 28 files
+├── tests/                       # 477 pytest tests across 28 files
 ├── docs/
 │   ├── GUIDE.md                 # User guide
 │   └── THEORY.md                # This file
@@ -188,7 +188,7 @@ Quality grades: **A** (90%+), **B** (75%+), **C** (60%+), **D** (40%+), **F** (<
 
 ## 🧪 Test Suite
 
-472 pytest tests across 28 files:
+477 pytest tests across 28 files:
 
 | Test File | Tests | Coverage |
 |-----------|-------|----------|
@@ -213,7 +213,7 @@ Quality grades: **A** (90%+), **B** (75%+), **C** (60%+), **D** (40%+), **F** (<
 | `test_validator.py` | 10 | Report structure, z-test, grades, dropout range |
 | `test_calibration.py` | 11 | Interpolation, clamping, confidence, range estimation |
 | `test_oulad_export.py` | 35 | Mappings, 7-table export, schema, determinism |
-| `test_benchmarks.py` | 10 | Profiles, generator, error handling |
+| `test_benchmarks.py` | 15 | Profiles, generator, report formatting, error handling |
 | `test_environment.py` | 4 | Courses, exam weeks, positive events |
 | `test_utils.py` | 14 | Validation helpers, logging config |
 | `test_network_scaling.py` | 4 | Degree cap, sampling threshold |


### PR DESCRIPTION
## Summary
- Add `--benchmark` CLI command to README Quick Start and Key Features
- Update GUIDE.md benchmark profiles section with new dropout ranges and CLI/Python API examples
- Update THEORY.md test counts (472 → 477) and test_benchmarks (10 → 15)
- Add benchmark reports to README roadmap as completed

## Test plan
- [x] 477 tests pass, lint clean
- [x] No code changes, docs only