### PR TITLE
feat: dual-track GPA — decouple transcript from dropout signals

### DIFF
--- a/synthed/analysis/sobol_sensitivity.py
+++ b/synthed/analysis/sobol_sensitivity.py
@@ -97,6 +97,8 @@ SOBOL_PARAMETER_SPACE: tuple[SobolParameter, ...] = (
 
     # ── Baulke: Dropout phase thresholds ──
     SobolParameter("baulke._NONFIT_ENG_THRESHOLD", 0.30, 0.55, "Non-fit perception trigger"),
+    SobolParameter("baulke._NONFIT_MASTERY_THRESHOLD", 0.25, 0.55, "Mastery below this → non-fit"),
+    SobolParameter("baulke._TRIGGER_MASTERY_THRESHOLD", 0.15, 0.45, "Mastery below this → phase 4-5 trigger"),
     SobolParameter("baulke._DECISION_RISK_MULTIPLIER", 0.10, 0.50, "Phase 5 risk multiplier"),
     SobolParameter("baulke._PHASE_2_TO_3_ENG", 0.20, 0.45, "Phase 2→3 threshold"),
     SobolParameter("baulke._PHASE_3_TO_4_ENG", 0.15, 0.35, "Phase 3→4 threshold"),

--- a/synthed/simulation/engine.py
+++ b/synthed/simulation/engine.py
@@ -79,6 +79,8 @@ class SimulationState:
     cumulative_gpa: float = 0.0
     gpa_points_sum: float = 0.0  # running sum of quality scores scaled to 4.0
     gpa_count: int = 0           # number of graded items (assignments + exams)
+    perceived_mastery_sum: float = 0.0   # running sum of raw quality (uninflated)
+    perceived_mastery_count: int = 0     # number of graded items for mastery track
     courses_active: list[str] = field(default_factory=list)
     has_dropped_out: bool = False
     dropout_week: int | None = None
@@ -96,6 +98,13 @@ class SimulationState:
     coping_factor: float = 0.0  # 0.0-0.5; reduces environmental pressure impact
     # Temporal memory (moved from StudentPersona to avoid mutating input)
     memory: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def perceived_mastery(self) -> float:
+        """Raw quality average (uninflated by grade floor). Returns 0.5 when no items recorded."""
+        if self.perceived_mastery_count == 0:
+            return 0.5
+        return self.perceived_mastery_sum / self.perceived_mastery_count
 
 
 class SimulationEngine:
@@ -353,6 +362,8 @@ class SimulationEngine:
         state.gpa_points_sum += graded * self._GPA_SCALE
         state.gpa_count += 1
         state.cumulative_gpa = state.gpa_points_sum / state.gpa_count
+        state.perceived_mastery_sum += quality
+        state.perceived_mastery_count += 1
 
     def _simulate_student_week(
         self, student: StudentPersona, state: SimulationState,

--- a/synthed/simulation/theories/baulke.py
+++ b/synthed/simulation/theories/baulke.py
@@ -29,6 +29,8 @@ class BaulkeDropoutPhase:
     _NONFIT_GPA_MIN_ITEMS: int = 2             # minimum graded items for non-fit GPA signal
     _TRIGGER_GPA_THRESHOLD: float = 1.2        # GPA below this is an additional phase 4->5 trigger
     _TRIGGER_GPA_MIN_ITEMS: int = 2            # minimum graded items for phase 4->5 GPA trigger
+    _NONFIT_MASTERY_THRESHOLD: float = 0.4    # perceived mastery below this contributes to non-fit
+    _TRIGGER_MASTERY_THRESHOLD: float = 0.3   # perceived mastery below this is phase 4->5 trigger
 
     # ── phase 1 → 0 / 1 → 2 ──
     _RECOVERY_1_TO_0: float = 0.50               # engagement above this recovers to phase 0
@@ -96,8 +98,8 @@ class BaulkeDropoutPhase:
                     or (eng < self._NONFIT_ENG_SOFT and avg_td > self._NONFIT_TD_THRESHOLD)
                     or (eng < self._NONFIT_ENG_SOFT and exhausted)
                     or (eng < self._NONFIT_ENG_SOFT
-                        and state.gpa_count >= self._NONFIT_GPA_MIN_ITEMS
-                        and state.cumulative_gpa < self._NONFIT_GPA_THRESHOLD)):
+                        and state.perceived_mastery_count >= self._NONFIT_GPA_MIN_ITEMS
+                        and state.perceived_mastery < self._NONFIT_MASTERY_THRESHOLD)):
                 state.dropout_phase = 1
                 state.memory.append({"week": week, "event_type": "dropout_phase",
                                     "details": "Non-fit perception: questioning fit with program",
@@ -165,9 +167,9 @@ class BaulkeDropoutPhase:
                     triggers += 1  # Bean & Metzner: environmental crisis
                 if exhausted:
                     triggers += 1  # Gonzalez: academic exhaustion crisis
-                if (state.gpa_count >= self._TRIGGER_GPA_MIN_ITEMS
-                        and state.cumulative_gpa < self._TRIGGER_GPA_THRESHOLD):
-                    triggers += 1  # Academic failure: GPA below recoverable threshold
+                if (state.perceived_mastery_count >= self._TRIGGER_GPA_MIN_ITEMS
+                        and state.perceived_mastery < self._TRIGGER_MASTERY_THRESHOLD):
+                    triggers += 1  # Academic failure: mastery below recoverable threshold
                 # Withdrawal deadline at ~70% of semester (Kember)
                 withdrawal_week = int(env.total_weeks * self._WITHDRAWAL_WEEK_FRACTION)
                 if week == withdrawal_week:

--- a/synthed/simulation/theories/kember.py
+++ b/synthed/simulation/theories/kember.py
@@ -62,9 +62,9 @@ class KemberCostBenefit:
         ) / 3
         state.perceived_cost_benefit += (coi_composite - 0.4) * self._COI_COMPOSITE_FACTOR
 
-        # GPA -> Kember: cumulative academic outcomes modulate perceived value
-        if state.gpa_count > 0:
-            gpa_normalized = state.cumulative_gpa / self._GPA_SCALE
-            state.perceived_cost_benefit += (gpa_normalized - 0.5) * self._GPA_CB_FACTOR
+        # Perceived mastery -> Kember: student's actual understanding modulates perceived value
+        if state.perceived_mastery_count > 0:
+            mastery = state.perceived_mastery
+            state.perceived_cost_benefit += (mastery - 0.5) * self._GPA_CB_FACTOR
 
         state.perceived_cost_benefit = float(np.clip(state.perceived_cost_benefit, self._CLIP_LO, self._CLIP_HI))

--- a/synthed/simulation/theories/sdt_motivation.py
+++ b/synthed/simulation/theories/sdt_motivation.py
@@ -107,10 +107,10 @@ class SDTMotivationDynamics:
 
         # Self-efficacy provides a small buffer
         competence_delta += (student.self_efficacy - 0.5) * self._COMPETENCE_EFFICACY_FACTOR
-        # Cumulative GPA anchors competence belief to overall trajectory
-        if state.gpa_count > 0:
-            gpa_normalized = state.cumulative_gpa / self._GPA_SCALE
-            competence_delta += (gpa_normalized - 0.5) * self._COMPETENCE_GPA_FACTOR
+        # Perceived mastery anchors competence belief to actual understanding
+        if state.perceived_mastery_count > 0:
+            mastery = state.perceived_mastery
+            competence_delta += (mastery - 0.5) * self._COMPETENCE_GPA_FACTOR
         needs.competence = float(np.clip(needs.competence + competence_delta, self._NEED_CLIP_LO, self._NEED_CLIP_HI))
 
         # ── Relatedness ──

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -73,6 +73,8 @@ class TestBaulkeEdgeCases:
             current_engagement=0.15,
             cumulative_gpa=1.0,
             gpa_count=3,
+            perceived_mastery_sum=0.0,
+            perceived_mastery_count=3,
             dropout_phase=0,
         )
 

--- a/tests/test_dual_track_gpa.py
+++ b/tests/test_dual_track_gpa.py
@@ -1,0 +1,46 @@
+"""Tests for dual-track GPA: transcript GPA vs perceived mastery."""
+from synthed.simulation.engine import SimulationState, SimulationEngine
+from synthed.simulation.environment import ODLEnvironment
+
+
+class TestSimulationStateMasteryFields:
+    def test_initial_mastery_fields_exist(self):
+        state = SimulationState(student_id="test-001")
+        assert state.perceived_mastery_sum == 0.0
+        assert state.perceived_mastery_count == 0
+
+    def test_perceived_mastery_property_no_items(self):
+        state = SimulationState(student_id="test-001")
+        assert state.perceived_mastery == 0.5
+
+    def test_perceived_mastery_property_with_items(self):
+        state = SimulationState(student_id="test-001")
+        state.perceived_mastery_sum = 1.2
+        state.perceived_mastery_count = 3
+        assert abs(state.perceived_mastery - 0.4) < 1e-9
+
+
+class TestRecordGradedItemDualTrack:
+    def test_graded_item_updates_both_tracks(self):
+        engine = SimulationEngine(environment=ODLEnvironment(), seed=42)
+        state = SimulationState(student_id="test-001")
+        engine._record_graded_item(state, 0.6)
+        assert state.gpa_count == 1
+        assert abs(state.cumulative_gpa - 3.12) < 0.01
+        assert state.perceived_mastery_count == 1
+        assert abs(state.perceived_mastery - 0.6) < 1e-9
+
+    def test_graded_item_mastery_diverges_from_gpa(self):
+        engine = SimulationEngine(environment=ODLEnvironment(), seed=42)
+        state = SimulationState(student_id="test-001")
+        for q in [0.3, 0.5, 0.7]:
+            engine._record_graded_item(state, q)
+        assert abs(state.perceived_mastery - 0.5) < 1e-9
+        assert state.cumulative_gpa > 2.0
+
+    def test_mastery_zero_quality(self):
+        engine = SimulationEngine(environment=ODLEnvironment(), seed=42)
+        state = SimulationState(student_id="test-001")
+        engine._record_graded_item(state, 0.0)
+        assert abs(state.perceived_mastery - 0.0) < 1e-9
+        assert state.cumulative_gpa > 0.0

--- a/tests/test_dual_track_gpa.py
+++ b/tests/test_dual_track_gpa.py
@@ -1,6 +1,12 @@
 """Tests for dual-track GPA: transcript GPA vs perceived mastery."""
+import numpy as np
+
 from synthed.simulation.engine import SimulationState, SimulationEngine
 from synthed.simulation.environment import ODLEnvironment
+from synthed.simulation.theories.kember import KemberCostBenefit
+from synthed.simulation.theories.sdt_motivation import SDTMotivationDynamics, SDTNeedSatisfaction
+from synthed.simulation.theories.baulke import BaulkeDropoutPhase
+from synthed.agents.persona import StudentPersona
 
 
 class TestSimulationStateMasteryFields:
@@ -44,3 +50,147 @@ class TestRecordGradedItemDualTrack:
         engine._record_graded_item(state, 0.0)
         assert abs(state.perceived_mastery - 0.0) < 1e-9
         assert state.cumulative_gpa > 0.0
+
+
+class TestKemberUsesPerceivedMastery:
+    """Kember cost-benefit must be driven by perceived mastery, not transcript GPA."""
+
+    def test_high_gpa_low_mastery_does_not_boost_cost_benefit(self):
+        """High transcript GPA with low mastery (0.3) should not produce positive GPA boost."""
+        kember = KemberCostBenefit()
+        student = StudentPersona()
+        state = SimulationState(
+            student_id="test-001",
+            perceived_cost_benefit=0.5,
+            cumulative_gpa=3.2,
+            gpa_count=5,
+            missed_assignments_streak=0,
+        )
+        state.perceived_mastery_sum = 1.5   # mastery = 0.3
+        state.perceived_mastery_count = 5
+        initial_cb = state.perceived_cost_benefit
+        # neutral quality record so quality factor doesn't dominate
+        from synthed.simulation.engine import InteractionRecord
+        records = [
+            InteractionRecord(student_id="test-001", week=5, course_id="CS101",
+                              interaction_type="assignment_submit", quality_score=0.5),
+        ]
+        kember.recalculate(student, state, {}, records, avg_td=0.5)
+        # mastery=0.3 < 0.5: GPA contribution should be negative, not positive
+        # The _GPA_CB_FACTOR is 0.01, mastery-0.5 = -0.2, delta = -0.002
+        # So cost_benefit must NOT have risen by more than a tiny rounding margin
+        assert state.perceived_cost_benefit <= initial_cb + 0.003
+
+    def test_low_gpa_high_mastery_boosts_cost_benefit(self):
+        """Low transcript GPA with high mastery (0.8) should yield positive mastery contribution."""
+        kember = KemberCostBenefit()
+        student = StudentPersona()
+        state = SimulationState(
+            student_id="test-001",
+            perceived_cost_benefit=0.5,
+            cumulative_gpa=1.2,
+            gpa_count=5,
+            missed_assignments_streak=0,
+        )
+        state.perceived_mastery_sum = 4.0   # mastery = 0.8
+        state.perceived_mastery_count = 5
+        from synthed.simulation.engine import InteractionRecord
+        records = [
+            InteractionRecord(student_id="test-001", week=5, course_id="CS101",
+                              interaction_type="assignment_submit", quality_score=0.5),
+        ]
+        kember.recalculate(student, state, {}, records, avg_td=0.5)
+        # mastery=0.8 > 0.5 → positive contribution; previous GPA=1.2 would have been negative
+        assert state.perceived_cost_benefit > 0.5
+
+
+class TestSDTUsesPerceivedMastery:
+    """SDT competence need must be anchored to perceived mastery, not transcript GPA."""
+
+    def test_high_gpa_low_mastery_limits_competence_boost(self):
+        """High transcript GPA (3.5) with low mastery (0.3) should NOT boost competence."""
+        sdt = SDTMotivationDynamics()
+        student = StudentPersona(self_efficacy=0.5)
+        state = SimulationState(
+            student_id="test-001",
+            current_engagement=0.5,
+            cumulative_gpa=3.5,
+            gpa_count=5,
+        )
+        state.sdt_needs = SDTNeedSatisfaction(competence=0.5)
+        state.perceived_mastery_sum = 1.5   # mastery = 0.3
+        state.perceived_mastery_count = 5
+        from synthed.simulation.engine import InteractionRecord
+        records = [
+            InteractionRecord(student_id="test-001", week=5, course_id="CS101",
+                              interaction_type="assignment_submit", quality_score=0.5),
+        ]
+        sdt.update_needs(student, state, 5, records)
+        # mastery=0.3 → negative contribution; GPA would have been strongly positive
+        competence_change = state.sdt_needs.competence - 0.5
+        assert competence_change < 0.003
+
+    def test_low_gpa_high_mastery_boosts_competence(self):
+        """Low transcript GPA (1.2) with high mastery (0.8) should boost competence."""
+        sdt = SDTMotivationDynamics()
+        student = StudentPersona(self_efficacy=0.5)
+        state = SimulationState(
+            student_id="test-001",
+            current_engagement=0.5,
+            cumulative_gpa=1.2,
+            gpa_count=5,
+        )
+        state.sdt_needs = SDTNeedSatisfaction(competence=0.5)
+        state.perceived_mastery_sum = 4.0   # mastery = 0.8
+        state.perceived_mastery_count = 5
+        from synthed.simulation.engine import InteractionRecord
+        records = [
+            InteractionRecord(student_id="test-001", week=5, course_id="CS101",
+                              interaction_type="assignment_submit", quality_score=0.5),
+        ]
+        sdt.update_needs(student, state, 5, records)
+        # mastery=0.8 → positive contribution; old GPA=1.2 would have been negative
+        assert state.sdt_needs.competence > 0.5
+
+
+class TestBaulkeUsesPerceivedMastery:
+    """Baulke phase transitions must use perceived mastery, not transcript GPA."""
+
+    def test_nonfit_triggers_on_low_mastery_not_high_gpa(self):
+        """Low mastery (0.3) with soft engagement should trigger non-fit even when GPA is high."""
+        baulke = BaulkeDropoutPhase()
+        student = StudentPersona()
+        state = SimulationState(
+            student_id="test-001",
+            current_engagement=0.43,  # above _NONFIT_ENG_THRESHOLD(0.40), below _NONFIT_ENG_SOFT(0.45)
+            dropout_phase=0,
+            cumulative_gpa=3.5,   # high GPA — old code would NOT trigger
+            gpa_count=3,
+        )
+        state.perceived_mastery_sum = 0.9   # mastery = 0.3 < _NONFIT_MASTERY_THRESHOLD(0.4)
+        state.perceived_mastery_count = 3
+        env = ODLEnvironment()
+        rng = np.random.default_rng(42)
+        baulke.advance_phase(student, state, 5, env, lambda s, st: 0.5, rng)
+        # Should advance because mastery is below the threshold
+        assert state.dropout_phase == 1
+
+    def test_nonfit_does_not_trigger_high_mastery_soft_engagement(self):
+        """High mastery (0.8) at soft engagement should NOT trigger non-fit on mastery condition."""
+        baulke = BaulkeDropoutPhase()
+        student = StudentPersona()
+        state = SimulationState(
+            student_id="test-001",
+            current_engagement=0.43,  # between thresholds
+            dropout_phase=0,
+            cumulative_gpa=1.0,   # low GPA — old code would trigger
+            gpa_count=3,
+        )
+        state.perceived_mastery_sum = 4.0   # mastery = 0.8 — high, no trigger
+        state.perceived_mastery_count = 5
+        env = ODLEnvironment()
+        rng = np.random.default_rng(42)
+        baulke.advance_phase(student, state, 5, env, lambda s, st: 0.5, rng)
+        # High mastery → mastery condition not met; other soft conditions not active
+        # (no exhaustion, no high TD, cognitive presence is default 0.5 > _NONFIT_COG_THRESHOLD)
+        assert state.dropout_phase == 0

--- a/tests/test_theories.py
+++ b/tests/test_theories.py
@@ -183,6 +183,8 @@ class TestKemberGPAFeedback:
             missed_assignments_streak=0,
             cumulative_gpa=1.2,
             gpa_count=5,
+            perceived_mastery_sum=0.0,
+            perceived_mastery_count=5,
         )
         records = [
             InteractionRecord(student_id="test", week=1, course_id="CS101",
@@ -215,6 +217,8 @@ class TestBaulkeGPAFeedback:
             dropout_phase=0,
             cumulative_gpa=1.4,
             gpa_count=3,
+            perceived_mastery_sum=0.0,
+            perceived_mastery_count=3,
         )
         env = ODLEnvironment()
         rng = np.random.default_rng(42)
@@ -262,6 +266,8 @@ class TestSDTGPAFeedback:
         state = _make_state(
             cumulative_gpa=3.6,
             gpa_count=5,
+            perceived_mastery_sum=4.091,
+            perceived_mastery_count=5,
         )
         state.sdt_needs = SDTNeedSatisfaction(competence=0.5)
         records = [
@@ -278,6 +284,8 @@ class TestSDTGPAFeedback:
         state = _make_state(
             cumulative_gpa=1.2,
             gpa_count=5,
+            perceived_mastery_sum=0.0,
+            perceived_mastery_count=5,
         )
         state.sdt_needs = SDTNeedSatisfaction(competence=0.5)
         records = [


### PR DESCRIPTION
## Summary
- Separate transcript GPA (grade-floor applied) from perceived mastery (raw quality) in SimulationState
- Theory modules (Kember, SDT, Baulke) now use perceived mastery for dropout-related calculations
- Transcript GPA remains unchanged for export/validation — dropout signals use uninflated quality

### Phase 1 of [v1.0.0 Roadmap](docs/superpowers/specs/2026-04-02-v1-roadmap-design.md)

### Benchmark Results (4/4 in range, GPA unchanged)

| Profile | v0.7.0 Dropout | Dual-Track Dropout | GPA | Validation |
| --- | ---: | ---: | ---: | --- |
| low_dropout_corporate | 7.0% | 5.7% | 2.90 | B |
| moderate_dropout_western | 31.4% | 32.4% | 2.87 | B |
| mega_university | 45.1% | 48.0% | 2.86 | A |
| high_dropout_developing | 58.2% | 60.2% | 2.85 | B |

## Test plan
- [x] 489 tests pass (477 + 12 new), lint clean
- [x] All 4 benchmark profiles within expected dropout range
- [x] Transcript GPA unchanged across all profiles
- [x] Sobol parameter space updated (55 params)
- [ ] CI passes on all Python versions