### PR TITLE
feat: add environmental shocks mechanism (Phase 3)

### DIFF
--- a/synthed/analysis/sobol_sensitivity.py
+++ b/synthed/analysis/sobol_sensitivity.py
@@ -89,6 +89,9 @@ SOBOL_PARAMETER_SPACE: tuple[SobolParameter, ...] = (
     SobolParameter("bean._FAMILY_PENALTY", 0.005, 0.04, "Family responsibility penalty"),
     SobolParameter("bean._FINANCIAL_PENALTY", 0.005, 0.03, "Financial stress penalty"),
     SobolParameter("bean._DISABILITY_PENALTY", 0.005, 0.03, "Disability engagement erosion"),
+    SobolParameter("bean._SHOCK_BASE_PROB", 0.02, 0.08, "Weekly shock probability"),
+    SobolParameter("bean._SHOCK_EMPLOY_WEIGHT", 0.1, 0.5, "Employment → shock risk"),
+    SobolParameter("bean._SHOCK_STRESS_WEIGHT", 0.2, 0.6, "Financial stress → shock risk"),
 
     # ── Kember: Cost-benefit ──
     SobolParameter("kember._QUALITY_FACTOR", 0.01, 0.08, "Quality → cost-benefit sensitivity"),

--- a/synthed/simulation/engine.py
+++ b/synthed/simulation/engine.py
@@ -96,6 +96,9 @@ class SimulationState:
     exhaustion: ExhaustionState = field(default_factory=ExhaustionState)
     # Bean & Metzner coping adaptation (Lazarus & Folkman, 1984)
     coping_factor: float = 0.0  # 0.0-0.5; reduces environmental pressure impact
+    # Environmental shocks (Bean & Metzner: acute life events)
+    env_shock_remaining: int = 0        # weeks remaining for active shock
+    env_shock_magnitude: float = 0.0    # engagement penalty per week during shock
     # Temporal memory (moved from StudentPersona to avoid mutating input)
     memory: list[dict[str, Any]] = field(default_factory=list)
 
@@ -521,6 +524,24 @@ class SimulationEngine:
         # ── Bean & Metzner: Environmental pressure (with coping attenuation) ──
         self.bean_metzner.update_coping(student, state)
         engagement += self.bean_metzner.calculate_environmental_pressure(student, state.coping_factor)
+
+        # ── Environmental shocks: stochastic life events ──
+        if state.env_shock_remaining > 0:
+            engagement -= state.env_shock_magnitude * 0.05
+            state.env_shock_remaining -= 1
+            if state.env_shock_remaining == 0:
+                state.env_shock_magnitude = 0.0
+        else:
+            duration, magnitude = self.bean_metzner.stochastic_pressure_event(student, self.rng)
+            if duration > 0:
+                state.env_shock_remaining = duration
+                state.env_shock_magnitude = magnitude
+                engagement -= magnitude * 0.05
+                state.memory.append({
+                    "week": week, "event_type": "env_shock",
+                    "details": f"Environmental shock (magnitude={magnitude:.2f}, duration={duration}w)",
+                    "impact": -magnitude * 0.05,
+                })
 
         # ── Positive environmental events (counter-pressure) ──
         engagement += self.positive_events.apply(

--- a/synthed/simulation/theories/baulke.py
+++ b/synthed/simulation/theories/baulke.py
@@ -40,6 +40,7 @@ class BaulkeDropoutPhase:
     # ── phase 2 → 1 / 2 → 3 ──
     _RECOVERY_2_TO_1: float = 0.45               # engagement above this recovers to phase 1
     _PHASE_2_TO_3_ENG: float = 0.32              # engagement below this advances to phase 3
+    _SHOCK_SEVERITY_THRESHOLD: float = 0.7       # shock magnitude above this triggers phase 2→3
 
     # ── phase 3 → 2 / 3 → 4 ──
     _RECOVERY_3_TO_2: float = 0.40               # engagement above this recovers to phase 2
@@ -128,8 +129,10 @@ class BaulkeDropoutPhase:
                 state.memory.append({"week": week, "event_type": "recovery",
                                     "details": "Renewed commitment, thoughts of quitting subsided",
                                     "impact": self._IMPACT_RECOVERY_2_TO_1})
-            # Phase 2 -> 3: Deliberation (requires sustained decline)
-            elif eng < self._PHASE_2_TO_3_ENG and len(history) >= 2 and history[-1] < history[-2]:
+            # Phase 2 -> 3: Deliberation (requires sustained decline or severe life shock)
+            elif (eng < self._PHASE_2_TO_3_ENG and len(history) >= 2 and history[-1] < history[-2]
+                    or (state.env_shock_remaining > 0
+                        and state.env_shock_magnitude > self._SHOCK_SEVERITY_THRESHOLD)):
                 state.dropout_phase = 3
                 state.memory.append({"week": week, "event_type": "dropout_phase",
                                     "details": "Deliberation: actively weighing whether to continue",

--- a/synthed/simulation/theories/bean_metzner.py
+++ b/synthed/simulation/theories/bean_metzner.py
@@ -25,6 +25,16 @@ class BeanMetznerPressure:
     _COPING_REG_WEIGHT: float = 0.60       # self-regulation weight in coping aptitude
     _COPING_CONSC_WEIGHT: float = 0.40     # conscientiousness weight in coping aptitude
 
+    # ── Environmental shocks ──
+    _SHOCK_BASE_PROB: float = 0.04
+    _SHOCK_EMPLOY_WEIGHT: float = 0.3
+    _SHOCK_FAMILY_WEIGHT: float = 0.3
+    _SHOCK_STRESS_WEIGHT: float = 0.4
+    _SHOCK_MIN_DURATION: int = 1
+    _SHOCK_MAX_DURATION: int = 3
+    _SHOCK_MIN_MAGNITUDE: float = 0.3
+    _SHOCK_MAX_MAGNITUDE: float = 1.0
+
     def calculate_environmental_pressure(
         self, student: StudentPersona, coping_factor: float = 0.0,
     ) -> float:
@@ -44,6 +54,26 @@ class BeanMetznerPressure:
         if student.disability_severity > 0:
             env_pressure -= self._DISABILITY_PENALTY * student.disability_severity
         return env_pressure * (1.0 - coping_factor)
+
+    def stochastic_pressure_event(
+        self, student: StudentPersona, rng: np.random.Generator,
+    ) -> tuple[int, float]:
+        """Generate a stochastic environmental shock.
+
+        Returns (duration, magnitude) or (0, 0.0) if no shock occurs.
+        Risk is modulated by employment status, family responsibilities, and financial stress.
+        """
+        risk_score = (
+            (1.0 if student.is_employed else 0.0) * self._SHOCK_EMPLOY_WEIGHT
+            + (1.0 if student.has_family_responsibilities else 0.0) * self._SHOCK_FAMILY_WEIGHT
+            + student.financial_stress * self._SHOCK_STRESS_WEIGHT
+        )
+        shock_prob = self._SHOCK_BASE_PROB * risk_score
+        if rng.random() >= shock_prob:
+            return 0, 0.0
+        duration = int(rng.integers(self._SHOCK_MIN_DURATION, self._SHOCK_MAX_DURATION + 1))
+        magnitude = float(rng.uniform(self._SHOCK_MIN_MAGNITUDE, self._SHOCK_MAX_MAGNITUDE))
+        return duration, magnitude
 
     def update_coping(self, student: StudentPersona, state: SimulationState) -> None:
         """Advance coping_factor based on student aptitude (weekly call).

--- a/tests/test_environmental_shocks.py
+++ b/tests/test_environmental_shocks.py
@@ -1,0 +1,367 @@
+"""Tests for Environmental Shocks (Bean & Metzner Phase 3 — stochastic life events)."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from synthed.agents.persona import StudentPersona
+from synthed.agents.factory import StudentFactory
+from synthed.simulation.engine import SimulationEngine, SimulationState, CommunityOfInquiryState
+from synthed.simulation.environment import ODLEnvironment
+from synthed.simulation.theories.bean_metzner import BeanMetznerPressure
+from synthed.simulation.theories.baulke import BaulkeDropoutPhase
+from synthed.simulation.theories.sdt_motivation import SDTNeedSatisfaction
+from synthed.simulation.theories.academic_exhaustion import ExhaustionState
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_state(**kwargs) -> SimulationState:
+    defaults = dict(
+        student_id="test",
+        current_engagement=0.5,
+        academic_integration=0.5,
+        social_integration=0.3,
+        perceived_cost_benefit=0.6,
+        coi_state=CommunityOfInquiryState(),
+        sdt_needs=SDTNeedSatisfaction(),
+        exhaustion=ExhaustionState(),
+        weekly_engagement_history=[],
+    )
+    defaults.update(kwargs)
+    return SimulationState(**defaults)
+
+
+def _high_risk_student() -> StudentPersona:
+    """Student with maximum Bean & Metzner risk factors."""
+    return StudentPersona(
+        is_employed=True,
+        weekly_work_hours=40,
+        has_family_responsibilities=True,
+        financial_stress=0.9,
+    )
+
+
+def _low_risk_student() -> StudentPersona:
+    """Student with no Bean & Metzner risk factors."""
+    return StudentPersona(
+        is_employed=False,
+        weekly_work_hours=0,
+        has_family_responsibilities=False,
+        financial_stress=0.0,
+    )
+
+
+# ── 1. SimulationState shock fields ──────────────────────────────────────────
+
+
+class TestSimulationStateShockFields:
+    """Verify the two new shock fields exist and default to zero."""
+
+    def test_env_shock_remaining_exists(self):
+        state = _make_state()
+        assert hasattr(state, "env_shock_remaining")
+
+    def test_env_shock_magnitude_exists(self):
+        state = _make_state()
+        assert hasattr(state, "env_shock_magnitude")
+
+    def test_env_shock_remaining_default_zero(self):
+        state = _make_state()
+        assert state.env_shock_remaining == 0
+
+    def test_env_shock_magnitude_default_zero(self):
+        state = _make_state()
+        assert state.env_shock_magnitude == 0.0
+
+    def test_env_shock_remaining_is_int(self):
+        state = _make_state()
+        assert isinstance(state.env_shock_remaining, int)
+
+    def test_env_shock_magnitude_is_float(self):
+        state = _make_state()
+        assert isinstance(state.env_shock_magnitude, float)
+
+    def test_fields_can_be_set_at_construction(self):
+        state = _make_state(env_shock_remaining=2, env_shock_magnitude=0.5)
+        assert state.env_shock_remaining == 2
+        assert state.env_shock_magnitude == 0.5
+
+
+# ── 2. Shock generation ───────────────────────────────────────────────────────
+
+
+class TestShockGeneration:
+    """Tests for BeanMetznerPressure.stochastic_pressure_event."""
+
+    def test_method_exists(self):
+        bm = BeanMetznerPressure()
+        assert hasattr(bm, "stochastic_pressure_event")
+        assert callable(bm.stochastic_pressure_event)
+
+    def test_returns_tuple_of_two(self):
+        bm = BeanMetznerPressure()
+        rng = np.random.default_rng(0)
+        result = bm.stochastic_pressure_event(_high_risk_student(), rng)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+    def test_no_shock_returns_zero_zero(self):
+        """Low-risk student with biased RNG (random() always >= prob) → (0, 0.0)."""
+        bm = BeanMetznerPressure()
+        # Override base prob to 0 so shock never fires
+        bm._SHOCK_BASE_PROB = 0.0
+        rng = np.random.default_rng(42)
+        duration, magnitude = bm.stochastic_pressure_event(_high_risk_student(), rng)
+        assert duration == 0
+        assert magnitude == 0.0
+
+    def test_shock_duration_in_valid_range(self):
+        """When a shock fires, duration must be within [min, max]."""
+        bm = BeanMetznerPressure()
+        bm._SHOCK_BASE_PROB = 999.0  # force fire (risk_score * 999 >> 1)
+        rng = np.random.default_rng(7)
+        duration, _ = bm.stochastic_pressure_event(_high_risk_student(), rng)
+        assert bm._SHOCK_MIN_DURATION <= duration <= bm._SHOCK_MAX_DURATION
+
+    def test_shock_magnitude_in_valid_range(self):
+        """When a shock fires, magnitude must be within [min, max]."""
+        bm = BeanMetznerPressure()
+        bm._SHOCK_BASE_PROB = 999.0
+        rng = np.random.default_rng(7)
+        _, magnitude = bm.stochastic_pressure_event(_high_risk_student(), rng)
+        assert bm._SHOCK_MIN_MAGNITUDE <= magnitude <= bm._SHOCK_MAX_MAGNITUDE
+
+    def test_duration_is_int(self):
+        bm = BeanMetznerPressure()
+        bm._SHOCK_BASE_PROB = 999.0
+        rng = np.random.default_rng(7)
+        duration, _ = bm.stochastic_pressure_event(_high_risk_student(), rng)
+        assert isinstance(duration, int)
+
+    def test_magnitude_is_float(self):
+        bm = BeanMetznerPressure()
+        bm._SHOCK_BASE_PROB = 999.0
+        rng = np.random.default_rng(7)
+        _, magnitude = bm.stochastic_pressure_event(_high_risk_student(), rng)
+        assert isinstance(magnitude, float)
+
+    def test_high_risk_gets_more_shocks_than_low_risk(self):
+        """High-risk student should have materially higher shock probability."""
+        bm = BeanMetznerPressure()
+        rng_high = np.random.default_rng(0)
+        rng_low = np.random.default_rng(0)
+        n_trials = 1000
+        high_student = _high_risk_student()
+        low_student = _low_risk_student()
+
+        high_shocks = sum(
+            1 for _ in range(n_trials)
+            if bm.stochastic_pressure_event(high_student, rng_high)[0] > 0
+        )
+        low_shocks = sum(
+            1 for _ in range(n_trials)
+            if bm.stochastic_pressure_event(low_student, rng_low)[0] > 0
+        )
+        assert high_shocks > low_shocks
+
+    def test_low_risk_zero_probability(self):
+        """Student with no risk factors → risk_score=0 → shock_prob=0 → never fires."""
+        bm = BeanMetznerPressure()
+        rng = np.random.default_rng(42)
+        n_trials = 500
+        zero_risk = _low_risk_student()
+        shocks = sum(
+            1 for _ in range(n_trials)
+            if bm.stochastic_pressure_event(zero_risk, rng)[0] > 0
+        )
+        assert shocks == 0
+
+    def test_constants_exist_on_class(self):
+        bm = BeanMetznerPressure()
+        for attr in (
+            "_SHOCK_BASE_PROB", "_SHOCK_EMPLOY_WEIGHT", "_SHOCK_FAMILY_WEIGHT",
+            "_SHOCK_STRESS_WEIGHT", "_SHOCK_MIN_DURATION", "_SHOCK_MAX_DURATION",
+            "_SHOCK_MIN_MAGNITUDE", "_SHOCK_MAX_MAGNITUDE",
+        ):
+            assert hasattr(bm, attr), f"Missing constant: {attr}"
+
+
+# ── 3. Engine integration ─────────────────────────────────────────────────────
+
+
+class TestShockEngineIntegration:
+    """Run a small cohort through the engine and verify shock mechanics."""
+
+    @pytest.fixture
+    def engine_and_students(self):
+        env = ODLEnvironment()
+        engine = SimulationEngine(environment=env, seed=123)
+        factory = StudentFactory(seed=123)
+        students = factory.generate_population(n=50)
+        return engine, students
+
+    def test_simulation_runs_without_crash(self, engine_and_students):
+        engine, students = engine_and_students
+        records, states, _ = engine.run(students)
+        assert len(states) == 50
+
+    def test_shock_events_recorded_in_memory(self, engine_and_students):
+        """At least one student should have an env_shock memory event in a 50-student run."""
+        engine, students = engine_and_students
+        _, states, _ = engine.run(students)
+        shock_events = [
+            ev
+            for state in states.values()
+            for ev in state.memory
+            if ev.get("event_type") == "env_shock"
+        ]
+        # With 50 students × 14 weeks and high-risk profiles expected, we expect shocks
+        assert len(shock_events) >= 1
+
+    def test_shock_event_has_required_keys(self, engine_and_students):
+        """Every env_shock memory entry must have week, event_type, details, impact."""
+        engine, students = engine_and_students
+        _, states, _ = engine.run(students)
+        for state in states.values():
+            for ev in state.memory:
+                if ev.get("event_type") == "env_shock":
+                    assert "week" in ev
+                    assert "details" in ev
+                    assert "impact" in ev
+                    assert ev["impact"] < 0  # shocks always reduce engagement
+
+    def test_shock_remaining_resets_after_duration(self):
+        """After shock duration expires, env_shock_remaining must return to 0."""
+        state = _make_state(
+            student_id="shock_test",
+            env_shock_remaining=2,
+            env_shock_magnitude=0.8,
+        )
+        # Simulate two engagement update calls manually via the engagement path
+        # We directly step the state counters as the engine would
+        for _ in range(2):
+            if state.env_shock_remaining > 0:
+                state.env_shock_remaining -= 1
+                if state.env_shock_remaining == 0:
+                    state.env_shock_magnitude = 0.0
+
+        assert state.env_shock_remaining == 0
+        assert state.env_shock_magnitude == 0.0
+
+    def test_active_shock_reduces_engagement(self):
+        """When env_shock_remaining > 0, engagement decreases by magnitude * 0.05."""
+        state = _make_state(
+            student_id="shock_eng_test",
+            current_engagement=0.6,
+            env_shock_remaining=3,
+            env_shock_magnitude=1.0,
+        )
+        # Snapshot engagement before calling the engagement update
+        initial_engagement = state.current_engagement
+
+        # Simulate the shock penalty directly (as the engine does)
+        if state.env_shock_remaining > 0:
+            engagement = state.current_engagement
+            engagement -= state.env_shock_magnitude * 0.05
+            state.env_shock_remaining -= 1
+            if state.env_shock_remaining == 0:
+                state.env_shock_magnitude = 0.0
+            state.current_engagement = engagement
+
+        assert state.current_engagement < initial_engagement
+
+
+# ── 4. Baulke phase advance via severe shock ──────────────────────────────────
+
+
+class TestBaulkeShockPhaseAdvance:
+    """Severe env shock (above threshold) should push phase 2 → 3."""
+
+    def _make_baulke_state(self, eng: float, shock_remaining: int, shock_mag: float) -> SimulationState:
+        state = _make_state(
+            current_engagement=eng,
+            dropout_phase=2,
+            env_shock_remaining=shock_remaining,
+            env_shock_magnitude=shock_mag,
+            weekly_engagement_history=[eng - 0.01, eng],  # declining trend required by phase 2→3
+        )
+        return state
+
+    def test_severe_shock_advances_phase_2_to_3(self):
+        """A shock above _SHOCK_SEVERITY_THRESHOLD while in phase 2 should advance to phase 3."""
+        baulke = BaulkeDropoutPhase()
+        env = ODLEnvironment()
+
+        # Set engagement just above normal phase-2->3 threshold so only shock triggers it
+        # _PHASE_2_TO_3_ENG = 0.32; set eng=0.33 (above) but with severe shock
+        eng = 0.33
+        state = self._make_baulke_state(
+            eng=eng,
+            shock_remaining=2,
+            shock_mag=baulke._SHOCK_SEVERITY_THRESHOLD + 0.1,
+        )
+        student = _high_risk_student()
+
+        def avg_td_fn(s, st):
+            return 0.5
+
+        baulke.advance_phase(student, state, week=5, env=env, avg_td_fn=avg_td_fn,
+                             rng=np.random.default_rng(0))
+
+        assert state.dropout_phase == 3, (
+            f"Expected phase 3 but got {state.dropout_phase}. "
+            "Severe shock should trigger phase 2→3 advance."
+        )
+
+    def test_mild_shock_does_not_advance_phase_alone(self):
+        """A mild shock below threshold should NOT advance phase when engagement is acceptable."""
+        baulke = BaulkeDropoutPhase()
+        env = ODLEnvironment()
+
+        # Engagement above ALL thresholds so nothing else triggers advance
+        # _RECOVERY_2_TO_1 = 0.45; set eng=0.44 (just below recovery, above phase trigger)
+        # _PHASE_2_TO_3_ENG = 0.32; eng=0.44 is above so normal condition won't fire
+        eng = 0.44
+        state = self._make_baulke_state(
+            eng=eng,
+            shock_remaining=1,
+            shock_mag=baulke._SHOCK_SEVERITY_THRESHOLD - 0.1,
+        )
+        student = _high_risk_student()
+
+        def avg_td_fn(s, st):
+            return 0.4  # below _NONFIT_TD_THRESHOLD
+
+        baulke.advance_phase(student, state, week=5, env=env, avg_td_fn=avg_td_fn,
+                             rng=np.random.default_rng(0))
+
+        # Should stay at 2 (not advance to 3, not recover to 1)
+        assert state.dropout_phase == 2, (
+            f"Expected phase 2 but got {state.dropout_phase}. "
+            "Mild shock should not advance phase on its own."
+        )
+
+    def test_no_shock_does_not_advance_phase_at_acceptable_engagement(self):
+        """No active shock with acceptable engagement should not advance phase 2 → 3."""
+        baulke = BaulkeDropoutPhase()
+        env = ODLEnvironment()
+
+        eng = 0.44
+        state = self._make_baulke_state(eng=eng, shock_remaining=0, shock_mag=0.0)
+        student = _low_risk_student()
+
+        def avg_td_fn(s, st):
+            return 0.4
+
+        baulke.advance_phase(student, state, week=5, env=env, avg_td_fn=avg_td_fn,
+                             rng=np.random.default_rng(0))
+
+        assert state.dropout_phase == 2
+
+    def test_threshold_constant_exists(self):
+        baulke = BaulkeDropoutPhase()
+        assert hasattr(baulke, "_SHOCK_SEVERITY_THRESHOLD")
+        assert isinstance(baulke._SHOCK_SEVERITY_THRESHOLD, float)
+        assert 0.0 < baulke._SHOCK_SEVERITY_THRESHOLD < 1.0


### PR DESCRIPTION
## Summary
- Add stochastic life events (job loss, family crisis, financial emergency) to Bean & Metzner module
- Events trigger dropout independent of academic performance — 86.4% of real ODL dropout is non-academic (Gonzalez et al., 2025)
- Shock probability scales with employment, family responsibilities, and financial stress
- Severe shocks (magnitude > 0.7) can advance Baulke dropout phases directly
- 3 new Sobol parameters added (61 total)

### Phase 3 of [v1.0.0 Roadmap](docs/superpowers/specs/2026-04-02-v1-roadmap-design.md)

### Cumulative Impact (Phases 1-3 vs v0.7.0)

| Profile | v0.7.0 | Phase 3 | Total Change | GPA |
| --- | ---: | ---: | ---: | ---: |
| low_dropout_corporate | 7.0% | 9.0% | +2.0pp | 2.90 |
| moderate_dropout_western | 31.4% | 33.2% | +1.8pp | 2.87 |
| mega_university | 45.1% | 54.5% | +9.4pp | 2.88 |
| high_dropout_developing | 58.2% | 68.2% | +10.0pp | 2.85 |

## Test plan
- [x] 520 tests pass (494 + 26 new), lint clean
- [x] All 4 benchmark profiles within expected dropout range
- [x] GPA unchanged across all profiles
- [x] Shocks seeded from engine RNG for determinism
- [ ] CI passes on all Python versions