### PR TITLE
ci: add weekly lychee link checker

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,18 @@
+name: Links
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Monday 9am UTC
+  workflow_dispatch:
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check links in markdown files
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --exclude-mail --no-progress --timeout 30 '**/*.md'
+          fail: false  # Advisory, not blocking PRs


### PR DESCRIPTION
## Summary

- Weekly lychee link check (Monday 9am UTC) for all markdown files
- Non-blocking (advisory only, `fail: false`)
- Manual trigger available via `workflow_dispatch`
- Catches broken DOIs, badges, ORCID links, cross-references

## Test plan

- [x] Workflow syntax valid
- [ ] Manual dispatch after merge to verify links before v1.0.0 tag