### PR TITLE
refactor: consolidate 4 benchmark profiles into single default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ venv/
 # Output
 output/
 *.csv
-benchmarks/
+/benchmarks/
 oulad/
 
 # Test artifacts

--- a/run_calibration.py
+++ b/run_calibration.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
-"""Run NSGA-II calibration for all 4 benchmark profiles.
+"""Run NSGA-II calibration for the default benchmark profile.
 
 Usage:
-    python run_calibration.py                    # Full run (~3.5h)
+    python run_calibration.py                    # Full run
     python run_calibration.py --quick            # Quick test (~20 min)
-    python run_calibration.py --profile mega_university  # Single profile
+    python run_calibration.py --profile default  # Single profile (only 'default' available)
 """
 from __future__ import annotations
 
@@ -24,12 +24,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-PROFILE_NAMES = [
-    "high_dropout_developing",
-    "moderate_dropout_western",
-    "low_dropout_corporate",
-    "mega_university",
-]
+PROFILE_NAMES = ["default"]
 
 OUTPUT_DIR = Path("calibration_output")
 
@@ -61,7 +56,7 @@ def calibrate_profile(
 
     t0 = time.time()
     result = cal.run(
-        profile_name=profile_name,
+        profile=profile_name,
         pop_size=pop_size,
         n_trials=n_trials,
         sobol_rankings=rankings,
@@ -73,7 +68,7 @@ def calibrate_profile(
     logger.info("Validating knee-point (n=500, 3 seeds)...")
     d_mean, d_std, g_mean, g_std = cal.validate_solution(
         result.knee_point,
-        profile_name,
+        profile=profile_name,
         n_students=500,
         seeds=(42, 123, 456),
     )
@@ -120,14 +115,14 @@ def calibrate_profile(
 def main():
     parser = argparse.ArgumentParser(description="NSGA-II benchmark calibration")
     parser.add_argument("--quick", action="store_true", help="Quick test run")
-    parser.add_argument("--profile", type=str, help="Single profile name")
+    parser.add_argument("--profile", type=str, help="Profile name (default: 'default')")
     parser.add_argument("--seed", type=int, default=42)
     args = parser.parse_args()
 
     if args.quick:
         n_students, pop_size, n_trials, sobol_top_n = 50, 20, 500, 10
     else:
-        n_students, pop_size, n_trials, sobol_top_n = 100, 80, 8000, 20
+        n_students, pop_size, n_trials, sobol_top_n = 100, 160, 12800, 20
 
     profiles = [args.profile] if args.profile else PROFILE_NAMES
     OUTPUT_DIR.mkdir(exist_ok=True)

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -7,8 +7,8 @@ Usage:
     python run_pipeline.py --n 500             # 500 students
     python run_pipeline.py --n 100 --llm       # 100 students with LLM enrichment
     python run_pipeline.py --config configs/default.json
-    python run_pipeline.py --benchmark         # Run all 4 benchmark profiles
-    python run_pipeline.py --benchmark --benchmark-profile moderate_dropout_western
+    python run_pipeline.py --benchmark         # Run default benchmark profile
+    python run_pipeline.py --benchmark --benchmark-profile default
 """
 
 import argparse
@@ -63,7 +63,7 @@ def main():
     )
     parser.add_argument(
         "--benchmark-profile", type=str, default=None,
-        help="Run a specific benchmark profile (default: all profiles)",
+        help="Run a specific benchmark profile (available: 'default')",
     )
     args = parser.parse_args()
 

--- a/synthed/analysis/nsga2_calibrator.py
+++ b/synthed/analysis/nsga2_calibrator.py
@@ -5,7 +5,6 @@ import logging
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import fields
 from functools import partial
-from typing import TYPE_CHECKING
 
 import numpy as np
 import optuna
@@ -20,8 +19,7 @@ from .sobol_sensitivity import (
     SOBOL_PARAMETER_SPACE,
 )
 
-if TYPE_CHECKING:
-    from ..benchmarks.profiles import BenchmarkProfile
+from ..benchmarks.profiles import BenchmarkProfile
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +76,7 @@ class NSGAIICalibrator:
 
     def run(
         self,
-        profile_name: str,
+        profile: str | BenchmarkProfile,
         pop_size: int = 80,
         n_trials: int = 8000,
         sobol_rankings: list[SobolRanking] | None = None,
@@ -87,13 +85,17 @@ class NSGAIICalibrator:
         """Run NSGA-II calibration for a benchmark profile."""
         from ..benchmarks.profiles import PROFILES
 
-        if profile_name not in PROFILES:
-            raise NSGAIICalibrationError(
-                f"Unknown profile '{profile_name}'. "
-                f"Available: {list(PROFILES)}"
-            )
-
-        profile = PROFILES[profile_name]
+        if isinstance(profile, str):
+            if profile not in PROFILES:
+                raise NSGAIICalibrationError(
+                    f"Unknown profile '{profile}'. "
+                    f"Available: {list(PROFILES)}"
+                )
+            resolved = PROFILES[profile]
+            profile_name = profile
+        else:
+            resolved = profile
+            profile_name = resolved.name
 
         # Parameter selection
         if sobol_rankings is None:
@@ -115,10 +117,10 @@ class NSGAIICalibrator:
         )
 
         # Targets and fixed overrides
-        target_dropout = profile.reference_stats.dropout_rate
-        target_gpa = profile.reference_stats.gpa_mean
-        fixed_overrides = self._build_fixed_overrides(profile)
-        lo, hi = profile.expected_dropout_range
+        target_dropout = resolved.reference_stats.dropout_rate
+        target_gpa = resolved.reference_stats.gpa_mean
+        fixed_overrides = self._build_fixed_overrides(resolved)
+        lo, hi = resolved.expected_dropout_range
 
         # Objective (used in sequential mode only)
         def objective(trial: optuna.Trial) -> tuple[float, float]:
@@ -131,7 +133,7 @@ class NSGAIICalibrator:
                 overrides=overrides,
                 n_students=self._n_students,
                 seed=self._seed,
-                default_config=profile.persona_config,
+                default_config=resolved.persona_config,
                 calibration_mode=True,
             )
             trial.set_user_attr("achieved_dropout", result["dropout_rate"])
@@ -174,7 +176,7 @@ class NSGAIICalibrator:
 
         if self._n_workers > 1:
             self._run_parallel(
-                study, params, fixed_overrides, profile,
+                study, params, fixed_overrides, resolved,
                 target_dropout, target_gpa, n_trials, pop_size,
             )
         else:
@@ -314,7 +316,7 @@ class NSGAIICalibrator:
     def validate_solution(
         self,
         solution: ParetoSolution,
-        profile_name: str,
+        profile: str | BenchmarkProfile,
         n_students: int = 500,
         seeds: tuple[int, ...] = (42, 123, 456),
     ) -> tuple[float, float, float, float]:
@@ -325,8 +327,11 @@ class NSGAIICalibrator:
         """
         from ..benchmarks.profiles import PROFILES
 
-        profile = PROFILES[profile_name]
-        fixed = self._build_fixed_overrides(profile)
+        if isinstance(profile, str):
+            resolved = PROFILES[profile]
+        else:
+            resolved = profile
+        fixed = self._build_fixed_overrides(resolved)
 
         dropouts: list[float] = []
         gpas: list[float] = []
@@ -336,7 +341,7 @@ class NSGAIICalibrator:
                 overrides=overrides,
                 n_students=n_students,
                 seed=s,
-                default_config=profile.persona_config,
+                default_config=resolved.persona_config,
                 calibration_mode=True,
             )
             dropouts.append(result["dropout_rate"])

--- a/synthed/analysis/sobol_sensitivity.py
+++ b/synthed/analysis/sobol_sensitivity.py
@@ -63,7 +63,7 @@ class SobolParameter:
 #   "epstein."  → engine.epstein_axtell attribute
 #   "inst."     → InstitutionalConfig field (frozen, use replace())
 
-# Full parameter space: 66 parameters selected for theoretical importance
+# Full parameter space: 68 parameters selected for theoretical importance
 # and empirical impact on dropout/engagement/GPA outcomes.
 SOBOL_PARAMETER_SPACE: tuple[SobolParameter, ...] = (
     # ── PersonaConfig: Population characteristics ──
@@ -280,7 +280,7 @@ class SobolAnalyzer:
         Generate Sobol (Saltelli) sample matrix.
 
         With calc_second_order=False, total = n_samples * (D + 2).
-        Default: 128 * (66 + 2) = 8,704 simulations.
+        Default: 128 * (68 + 2) = 8,960 simulations.
         """
         return sobol_sample.sample(self._problem, n_samples, calc_second_order=False)
 

--- a/synthed/benchmarks/profiles.py
+++ b/synthed/benchmarks/profiles.py
@@ -8,6 +8,7 @@ datasets for research comparison.
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 
 from ..agents.persona import PersonaConfig
@@ -32,105 +33,38 @@ class BenchmarkProfile:
     grading_config: GradingConfig = GradingConfig()
 
 
-PROFILES: dict[str, BenchmarkProfile] = {
-    "high_dropout_developing": BenchmarkProfile(
-        name="high_dropout_developing",
-        description="Developing country ODL: high dropout (55-75%), high employment, low digital literacy",
-        persona_config=PersonaConfig(
-            employment_rate=0.85,
-            financial_stress_mean=0.65,
-            digital_literacy_mean=0.35,
-            self_regulation_mean=0.35,
-            dropout_base_rate=0.92,
-        ),
-        institutional_config=InstitutionalConfig(
-            instructional_design_quality=0.30,
-            teaching_presence_baseline=0.35,
-            support_services_quality=0.25,
-            technology_quality=0.35,
-            curriculum_flexibility=0.25,
-        ),
-        grading_config=GradingConfig(
-            distribution="beta", dist_alpha=3.0, dist_beta=4.0,
-            midterm_weight=0.30, final_weight=0.70,
-            midterm_components={"exam": 0.60, "assignment": 0.40},
-            exam_eligibility_threshold=0.30,
-            pass_threshold=0.63, distinction_threshold=0.71,
-        ),
-        environment=ODLEnvironment(total_weeks=14),
-        reference_stats=ReferenceStatistics(dropout_rate=0.65),
-        n_students=500,
-        seed=42,
-        expected_dropout_range=(0.55, 0.80),
-    ),
-    "moderate_dropout_western": BenchmarkProfile(
-        name="moderate_dropout_western",
-        description="Western university ODL: moderate dropout (15-35%), mixed employment",
-        persona_config=PersonaConfig(
-            employment_rate=0.55,
-            financial_stress_mean=0.45,
-            digital_literacy_mean=0.65,
-            self_regulation_mean=0.45,
-            dropout_base_rate=0.65,
-        ),
-        institutional_config=InstitutionalConfig(
-            instructional_design_quality=0.65,
-            teaching_presence_baseline=0.60,
-            support_services_quality=0.65,
-            technology_quality=0.75,
-            curriculum_flexibility=0.60,
-        ),
-        grading_config=GradingConfig(
-            distribution="beta", dist_alpha=6.0, dist_beta=2.0,
-            midterm_weight=0.50, final_weight=0.50,
-            midterm_components={"assignment": 1.0},
-            dual_hurdle=True,
-            component_pass_thresholds={"midterm": 0.40, "final": 0.40},
-            pass_threshold=0.58, distinction_threshold=0.67,
-        ),
-        environment=ODLEnvironment(total_weeks=14),
-        reference_stats=ReferenceStatistics(dropout_rate=0.25, age_mean=26.0),
-        n_students=500,
-        seed=42,
-        expected_dropout_range=(0.15, 0.35),
-    ),
-    "low_dropout_corporate": BenchmarkProfile(
-        name="low_dropout_corporate",
-        description="Corporate training ODL: low dropout (5-25%), employer-sponsored",
-        persona_config=PersonaConfig(
-            employment_rate=0.95,
-            financial_stress_mean=0.20,
-            digital_literacy_mean=0.75,
-            self_regulation_mean=0.65,
-            dropout_base_rate=0.25,
-            has_family_rate=0.45,
-        ),
-        institutional_config=InstitutionalConfig(
-            instructional_design_quality=0.85,
-            teaching_presence_baseline=0.80,
-            support_services_quality=0.90,
-            technology_quality=0.90,
-            curriculum_flexibility=0.80,
-        ),
-        grading_config=GradingConfig(
-            assessment_mode="exam_only",
-            midterm_weight=0.0, final_weight=1.0,
-            midterm_components={},
-            distribution="beta", dist_alpha=8.0, dist_beta=2.0,
-            pass_threshold=0.70,
-            distinction_threshold=0.79,
-        ),
-        environment=ODLEnvironment(total_weeks=14),
-        reference_stats=ReferenceStatistics(
-            dropout_rate=0.15, employment_rate=0.95, age_mean=32.0
-        ),
-        n_students=300,
-        seed=42,
-        expected_dropout_range=(0.01, 0.25),
-    ),
-    "mega_university": BenchmarkProfile(
-        name="mega_university",
-        description="Mega university: very high enrollment, elevated dropout (35-60%)",
+class _DeprecatedProfileDict(dict):
+    """Dict that warns on access to removed profile names."""
+
+    _ALIASES = {"mega_university": "default"}
+    _REMOVED = {"high_dropout_developing", "moderate_dropout_western", "low_dropout_corporate"}
+
+    def __getitem__(self, key):
+        if key in self._ALIASES:
+            warnings.warn(
+                f"Profile '{key}' renamed to '{self._ALIASES[key]}'. "
+                f"Use '{self._ALIASES[key]}' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return super().__getitem__(self._ALIASES[key])
+        if key in self._REMOVED:
+            raise KeyError(
+                f"Profile '{key}' has been removed. Use 'default' and "
+                f"customize via PersonaConfig/InstitutionalConfig/GradingConfig."
+            )
+        return super().__getitem__(key)
+
+    def __contains__(self, key):
+        if key in self._ALIASES:
+            return True
+        return super().__contains__(key)
+
+
+PROFILES: dict[str, BenchmarkProfile] = _DeprecatedProfileDict({
+    "default": BenchmarkProfile(
+        name="default",
+        description="Default ODL profile: large-scale, diverse student population",
         persona_config=PersonaConfig(
             age_range=(18, 60),
             employment_rate=0.80,
@@ -161,4 +95,4 @@ PROFILES: dict[str, BenchmarkProfile] = {
         seed=42,
         expected_dropout_range=(0.35, 0.60),
     ),
-}
+})

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import json
+import warnings
+
+import pytest
 
 from synthed.benchmarks.profiles import PROFILES, BenchmarkProfile
 from synthed.benchmarks.generator import BenchmarkGenerator
@@ -12,8 +15,8 @@ class TestBenchmarkProfiles:
     """Tests for the pre-defined benchmark profile registry."""
 
     def test_profiles_exist(self):
-        """PROFILES dict should have 4 entries."""
-        assert len(PROFILES) == 4
+        """PROFILES dict should have 1 entry."""
+        assert len(PROFILES) == 1
 
     def test_profile_structure(self):
         """Each profile should have required attributes."""
@@ -30,13 +33,23 @@ class TestBenchmarkProfiles:
 
     def test_profile_names(self):
         """Expected profile names should be present."""
-        expected = {
-            "high_dropout_developing",
-            "moderate_dropout_western",
-            "low_dropout_corporate",
-            "mega_university",
-        }
+        expected = {"default"}
         assert set(PROFILES.keys()) == expected
+
+    def test_deprecated_alias_warns(self):
+        """Accessing 'mega_university' should emit DeprecationWarning."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            profile = PROFILES["mega_university"]
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "renamed" in str(w[0].message)
+            assert profile.name == "default"
+
+    def test_removed_profile_raises(self):
+        """Accessing removed profiles should raise KeyError."""
+        with pytest.raises(KeyError, match="has been removed"):
+            PROFILES["high_dropout_developing"]
 
 
 class TestBenchmarkGenerator:
@@ -44,7 +57,7 @@ class TestBenchmarkGenerator:
 
     def test_generator_runs(self, tmp_path):
         """generate() with overridden small n_students should return valid report."""
-        profile = PROFILES["moderate_dropout_western"]
+        profile = PROFILES["default"]
 
         # Use the pipeline directly with small n_students
         from synthed.pipeline import SynthEdPipeline
@@ -67,7 +80,7 @@ class TestBenchmarkGenerator:
         profiles = gen.list_profiles()
 
         assert isinstance(profiles, dict)
-        assert len(profiles) == 4
+        assert len(profiles) == 1
         for name, desc in profiles.items():
             assert isinstance(name, str)
             assert isinstance(desc, str)
@@ -85,7 +98,7 @@ class TestBenchmarkGenerator:
         from unittest.mock import patch
 
         mock_report = {
-            "simulation_summary": {"dropout_rate": 0.15},
+            "simulation_summary": {"dropout_rate": 0.45},
         }
         with patch(
             "synthed.benchmarks.generator.SynthEdPipeline"
@@ -93,15 +106,15 @@ class TestBenchmarkGenerator:
             MockPipeline.return_value.run.return_value = mock_report
             gen = BenchmarkGenerator()
             report = gen.generate(
-                "low_dropout_corporate",
+                "default",
                 output_dir=str(tmp_path / "benchmark"),
             )
 
         assert "benchmark_validation" in report
         bv = report["benchmark_validation"]
-        assert bv["profile"] == "low_dropout_corporate"
-        assert bv["actual_dropout_rate"] == 0.15
-        # 0.15 is within (0.05, 0.30)
+        assert bv["profile"] == "default"
+        assert bv["actual_dropout_rate"] == 0.45
+        # 0.45 is within (0.35, 0.60)
         assert bv["in_expected_range"] is True
 
     def test_generate_valid_profile_out_of_range(self, tmp_path):
@@ -117,12 +130,12 @@ class TestBenchmarkGenerator:
             MockPipeline.return_value.run.return_value = mock_report
             gen = BenchmarkGenerator()
             report = gen.generate(
-                "low_dropout_corporate",
+                "default",
                 output_dir=str(tmp_path / "benchmark"),
             )
 
         bv = report["benchmark_validation"]
-        # 0.95 is outside (0.05, 0.30)
+        # 0.95 is outside (0.35, 0.60)
         assert bv["in_expected_range"] is False
 
     def test_generate_default_output_dir(self):
@@ -137,7 +150,7 @@ class TestBenchmarkGenerator:
         ) as MockPipeline:
             MockPipeline.return_value.run.return_value = mock_report
             gen = BenchmarkGenerator()
-            report = gen.generate("moderate_dropout_western")
+            report = gen.generate("default")
 
         assert "benchmark_validation" in report
 
@@ -192,12 +205,9 @@ class TestBenchmarkReport:
         }
 
     def test_format_report_contains_all_profiles(self):
-        """_format_report should mention every profile name."""
+        """_format_report should mention the default profile name."""
         results = [
-            self._make_mock_report("high_dropout_developing", dropout=0.72),
-            self._make_mock_report("moderate_dropout_western", dropout=0.45),
-            self._make_mock_report("low_dropout_corporate", dropout=0.15),
-            self._make_mock_report("mega_university", dropout=0.68),
+            self._make_mock_report("default", dropout=0.45),
         ]
         md = BenchmarkGenerator._format_report(results, elapsed=5.0)
 
@@ -206,7 +216,7 @@ class TestBenchmarkReport:
 
     def test_format_report_markdown_structure(self):
         """Report should have expected headers and table."""
-        results = [self._make_mock_report("moderate_dropout_western")]
+        results = [self._make_mock_report("default")]
         md = BenchmarkGenerator._format_report(results, elapsed=1.0)
 
         assert "# SynthEd Benchmark Report" in md
@@ -218,8 +228,8 @@ class TestBenchmarkReport:
     def test_format_report_in_range_flag(self):
         """YES/NO flags should match expected range."""
         results = [
-            self._make_mock_report("low_dropout_corporate", dropout=0.15),
-            self._make_mock_report("low_dropout_corporate", dropout=0.95),
+            self._make_mock_report("default", dropout=0.45),
+            self._make_mock_report("default", dropout=0.95),
         ]
         # Override the second to be out of range
         results[1]["benchmark_validation"]["in_expected_range"] = False
@@ -230,7 +240,7 @@ class TestBenchmarkReport:
 
     def test_format_report_handles_none_gpa(self):
         """Report should not crash when GPA or engagement is None."""
-        report = self._make_mock_report("moderate_dropout_western")
+        report = self._make_mock_report("default")
         report["simulation_summary"]["mean_final_gpa"] = None
         report["simulation_summary"]["mean_final_engagement"] = None
         report["simulation_summary"]["mean_dropout_week"] = None
@@ -243,7 +253,7 @@ class TestBenchmarkReport:
         """generate_report should write .md and .json files."""
         from unittest.mock import patch
 
-        mock_report = self._make_mock_report("moderate_dropout_western")
+        mock_report = self._make_mock_report("default")
         with patch(
             "synthed.benchmarks.generator.SynthEdPipeline"
         ) as MockPipeline:
@@ -259,7 +269,7 @@ class TestBenchmarkReport:
         # Verify JSON is valid
         data = json.loads((tmp_path / "benchmark_results.json").read_text())
         assert isinstance(data, list)
-        assert len(data) == 4
+        assert len(data) == 1
 
         # Verify markdown returned
         assert "# SynthEd Benchmark Report" in md

--- a/tests/test_institutional_integration.py
+++ b/tests/test_institutional_integration.py
@@ -84,10 +84,7 @@ class TestBenchmarkProfilesWithInstitutionalConfig:
     """Verify all 4 benchmark profiles stay in target range."""
 
     @pytest.mark.parametrize("profile_name", [
-        "high_dropout_developing",
-        "moderate_dropout_western",
-        "mega_university",
-        "low_dropout_corporate",
+        "default",
     ])
     def test_profile_in_expected_dropout_range(self, profile_name, tmp_path):
         from synthed.pipeline import SynthEdPipeline

--- a/tests/test_nsga2_calibrator.py
+++ b/tests/test_nsga2_calibrator.py
@@ -61,23 +61,23 @@ class TestNSGAIICalibrator:
     def test_build_fixed_overrides_includes_float_fields(self):
         from synthed.benchmarks.profiles import PROFILES
         cal = NSGAIICalibrator()
-        profile = PROFILES["moderate_dropout_western"]
+        profile = PROFILES["default"]
         overrides = cal._build_fixed_overrides(profile)
         assert "config.employment_rate" in overrides
         assert "inst.technology_quality" in overrides
-        assert overrides["inst.technology_quality"] == 0.75
+        assert overrides["inst.technology_quality"] == 0.60
 
     def test_build_fixed_overrides_excludes_bool_fields(self):
         from synthed.benchmarks.profiles import PROFILES
         cal = NSGAIICalibrator()
-        profile = PROFILES["moderate_dropout_western"]
+        profile = PROFILES["default"]
         overrides = cal._build_fixed_overrides(profile)
         assert "config.generate_names" not in overrides
 
     def test_build_fixed_overrides_all_values_are_float(self):
         from synthed.benchmarks.profiles import PROFILES
         cal = NSGAIICalibrator()
-        profile = PROFILES["moderate_dropout_western"]
+        profile = PROFILES["default"]
         overrides = cal._build_fixed_overrides(profile)
         for key, val in overrides.items():
             assert isinstance(val, float), f"{key} is not float: {type(val)}"
@@ -106,7 +106,7 @@ class TestNSGAIIIntegration:
 
         def _mock_sim(**kwargs):
             return {
-                "dropout_rate": 0.15 + rng.random() * 0.20,  # 0.15-0.35
+                "dropout_rate": 0.35 + rng.random() * 0.25,  # 0.35-0.60
                 "mean_gpa": 2.0 + rng.random() * 1.5,        # 2.0-3.5
                 "mean_engagement": 0.3 + rng.random() * 0.4,  # 0.3-0.7
             }
@@ -126,7 +126,7 @@ class TestNSGAIIIntegration:
 
         cal = NSGAIICalibrator(n_students=30, seed=42)
         result = cal.run(
-            profile_name="moderate_dropout_western",
+            profile="default",
             pop_size=5,
             n_trials=20,
             sobol_rankings=rankings,
@@ -134,7 +134,7 @@ class TestNSGAIIIntegration:
         )
 
         assert isinstance(result, ParetoResult)
-        assert result.profile_name == "moderate_dropout_western"
+        assert result.profile_name == "default"
         assert len(result.pareto_front) > 0
         assert result.knee_point is not None
         assert result.n_evaluations == 20
@@ -155,7 +155,7 @@ class TestNSGAIIIntegration:
         )
         d_mean, d_std, g_mean, g_std = cal.validate_solution(
             solution,
-            profile_name="moderate_dropout_western",
+            profile="default",
             n_students=30,
             seeds=(42, 123),
         )

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -81,11 +81,11 @@ class TestPipelineFromProfile:
     def test_from_profile_valid(self, tmp_path):
         """from_profile with a valid profile creates a properly configured pipeline."""
         pipeline = SynthEdPipeline.from_profile(
-            "low_dropout_corporate",
+            "default",
             output_dir=str(tmp_path),
         )
         assert pipeline._calibration_estimate is not None
-        assert pipeline.target_dropout_range == (0.01, 0.25)
+        assert pipeline.target_dropout_range == (0.35, 0.60)
         # Run to ensure it works end-to-end
         report = pipeline.run(n_students=20)
         assert "simulation_summary" in report


### PR DESCRIPTION
## Summary

- Replace 4 benchmark profiles (developing, western, corporate, mega) with single `"default"` profile based on mega university parameters
- Users customize via `PersonaConfig`, `InstitutionalConfig`, `GradingConfig` directly
- `_DeprecatedProfileDict`: `PROFILES["mega_university"]` warns, removed names raise `KeyError` with migration message
- `NSGAIICalibrator.run()` now accepts `str | BenchmarkProfile` (decoupled from registry)
- Fix `.gitignore`: `/benchmarks/` root-only (was blocking `synthed/benchmarks/`)

## Rationale

The 4 profiles mixed 3 different classification axes (country, institution type, scale) making comparison meaningless. A single default profile with user customization is simpler and more flexible.

## Test plan

- [x] 617 tests passing, lint clean
- [x] Deprecated alias test: `PROFILES["mega_university"]` emits DeprecationWarning
- [x] Removed profile test: `PROFILES["high_dropout_developing"]` raises KeyError
- [ ] CI passing

> **Note:** There may be a CI issue from the previous merge — please check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)