### PR TITLE
refactor: Phase A quick wins (P4, P6, P7, P8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to SynthEd are documented here.
 
+## [Unreleased]
+
+### Changed
+- `ODLEnvironment.get_course_by_id`: O(1) dict lookup replaces O(n) linear scan
+- `_sim_runner`: Calibration mode skips temp directory creation (I/O reduction)
+- `ReferenceStatistics` and `ValidationResult` extracted to `synthed/validation/types.py`
+
+### Added
+- Warning when `n_students < 100` (calibration reliability)
+
 ## [1.2.0] - 2026-04-05
 
 ### Added

--- a/docs/THEORY.md
+++ b/docs/THEORY.md
@@ -183,7 +183,7 @@ SynthEd/
 │   │   └── validation.py        # Input validation utilities
 │   ├── calibration.py           # CalibrationMap: target dropout -> params
 │   └── pipeline.py              # End-to-end orchestrator
-├── tests/                       # 635 pytest tests across 39 files
+├── tests/                       # 642 pytest tests across 39 files
 ├── docs/
 │   ├── GUIDE.md                 # User guide
 │   └── THEORY.md                # This file
@@ -212,7 +212,7 @@ Quality grades: **A** (90%+), **B** (75%+), **C** (60%+), **D** (40%+), **F** (<
 
 ## 🧪 Test Suite
 
-635 pytest tests across 39 files:
+642 pytest tests across 39 files:
 
 | Test File | Tests | Coverage |
 |-----------|-------|----------|

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from synthed.utils.log_config import configure_logging
 
 from synthed.agents.persona import PersonaConfig
-from synthed.validation.validator import ReferenceStatistics
+from synthed.validation import ReferenceStatistics
 from synthed.pipeline import SynthEdPipeline
 
 

--- a/synthed/analysis/_sim_runner.py
+++ b/synthed/analysis/_sim_runner.py
@@ -40,6 +40,28 @@ MODULE_ALIASES: dict[str, str] = {
 }
 
 
+def _extract_metrics(summary: dict) -> dict[str, float]:
+    """Extract standard metrics from a pipeline simulation_summary dict."""
+    engagement = summary.get("mean_final_engagement")
+    gpa = summary.get("mean_final_gpa")
+    engagement_std = summary.get("std_final_engagement")
+    if engagement is None:
+        logger.warning("mean_final_engagement missing from summary; defaulting to 0.0")
+        engagement = 0.0
+    if gpa is None:
+        logger.warning("mean_final_gpa missing from summary; defaulting to 0.0")
+        gpa = 0.0
+    return {
+        "dropout_rate": summary["dropout_rate"],
+        "mean_engagement": float(engagement),
+        "mean_gpa": float(gpa),
+        "std_engagement": float(engagement_std) if engagement_std is not None else 0.0,
+        "pass_rate": float(summary.get("pass_rate", 0.0)),
+        "distinction_rate": float(summary.get("distinction_rate", 0.0)),
+        "fail_rate": float(summary.get("fail_rate", 0.0)),
+    }
+
+
 def run_simulation_with_overrides(
     overrides: dict[str, float],
     n_students: int,
@@ -120,26 +142,7 @@ def run_simulation_with_overrides(
         _apply_engine_overrides(pipeline, engine_overrides, theory_overrides)
         report = pipeline.run(n_students=n_students)
 
-        summary = report["simulation_summary"]
-        engagement = summary.get("mean_final_engagement")
-        gpa = summary.get("mean_final_gpa")
-        engagement_std = summary.get("std_final_engagement")
-        if engagement is None:
-            logger.warning("mean_final_engagement missing from summary; defaulting to 0.0")
-            engagement = 0.0
-        if gpa is None:
-            logger.warning("mean_final_gpa missing from summary; defaulting to 0.0")
-            gpa = 0.0
-
-        return {
-            "dropout_rate": summary["dropout_rate"],
-            "mean_engagement": float(engagement),
-            "mean_gpa": float(gpa),
-            "std_engagement": float(engagement_std) if engagement_std is not None else 0.0,
-            "pass_rate": float(summary.get("pass_rate", 0.0)),
-            "distinction_rate": float(summary.get("distinction_rate", 0.0)),
-            "fail_rate": float(summary.get("fail_rate", 0.0)),
-        }
+        return _extract_metrics(report["simulation_summary"])
 
     tmp_dir = tempfile.mkdtemp(prefix="synthed_analysis_")
     try:
@@ -154,26 +157,7 @@ def run_simulation_with_overrides(
         _apply_engine_overrides(pipeline, engine_overrides, theory_overrides)
         report = pipeline.run(n_students=n_students)
 
-        summary = report["simulation_summary"]
-        engagement = summary.get("mean_final_engagement")
-        gpa = summary.get("mean_final_gpa")
-        engagement_std = summary.get("std_final_engagement")
-        if engagement is None:
-            logger.warning("mean_final_engagement missing from summary; defaulting to 0.0")
-            engagement = 0.0
-        if gpa is None:
-            logger.warning("mean_final_gpa missing from summary; defaulting to 0.0")
-            gpa = 0.0
-
-        return {
-            "dropout_rate": summary["dropout_rate"],
-            "mean_engagement": float(engagement),
-            "mean_gpa": float(gpa),
-            "std_engagement": float(engagement_std) if engagement_std is not None else 0.0,
-            "pass_rate": float(summary.get("pass_rate", 0.0)),
-            "distinction_rate": float(summary.get("distinction_rate", 0.0)),
-            "fail_rate": float(summary.get("fail_rate", 0.0)),
-        }
+        return _extract_metrics(report["simulation_summary"])
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)
 

--- a/synthed/analysis/_sim_runner.py
+++ b/synthed/analysis/_sim_runner.py
@@ -108,6 +108,39 @@ def run_simulation_with_overrides(
     else:
         grading_config = None
 
+    if calibration_mode:
+        pipeline = SynthEdPipeline(
+            persona_config=config,
+            output_dir=None,
+            seed=seed,
+            institutional_config=inst_config,
+            grading_config=grading_config,
+            _calibration_mode=True,
+        )
+        _apply_engine_overrides(pipeline, engine_overrides, theory_overrides)
+        report = pipeline.run(n_students=n_students)
+
+        summary = report["simulation_summary"]
+        engagement = summary.get("mean_final_engagement")
+        gpa = summary.get("mean_final_gpa")
+        engagement_std = summary.get("std_final_engagement")
+        if engagement is None:
+            logger.warning("mean_final_engagement missing from summary; defaulting to 0.0")
+            engagement = 0.0
+        if gpa is None:
+            logger.warning("mean_final_gpa missing from summary; defaulting to 0.0")
+            gpa = 0.0
+
+        return {
+            "dropout_rate": summary["dropout_rate"],
+            "mean_engagement": float(engagement),
+            "mean_gpa": float(gpa),
+            "std_engagement": float(engagement_std) if engagement_std is not None else 0.0,
+            "pass_rate": float(summary.get("pass_rate", 0.0)),
+            "distinction_rate": float(summary.get("distinction_rate", 0.0)),
+            "fail_rate": float(summary.get("fail_rate", 0.0)),
+        }
+
     tmp_dir = tempfile.mkdtemp(prefix="synthed_analysis_")
     try:
         pipeline = SynthEdPipeline(
@@ -116,7 +149,7 @@ def run_simulation_with_overrides(
             seed=seed,
             institutional_config=inst_config,
             grading_config=grading_config,
-            _calibration_mode=calibration_mode,
+            _calibration_mode=False,
         )
         _apply_engine_overrides(pipeline, engine_overrides, theory_overrides)
         report = pipeline.run(n_students=n_students)

--- a/synthed/benchmarks/profiles.py
+++ b/synthed/benchmarks/profiles.py
@@ -14,7 +14,7 @@ from ..agents.persona import PersonaConfig
 from ..simulation.environment import ODLEnvironment
 from ..simulation.grading import GradingConfig
 from ..simulation.institutional import InstitutionalConfig
-from ..validation.validator import ReferenceStatistics
+from ..validation import ReferenceStatistics
 
 
 @dataclass(frozen=True)

--- a/synthed/calibration.py
+++ b/synthed/calibration.py
@@ -40,8 +40,6 @@ class CalibrationEstimate:
 # Measured 2026-04-03 post GradingConfig addition.
 # IMPORTANT: Re-measure if theory modules, engine weights, or RNG-consuming
 #            code paths change (even non-dropout features shift RNG sequence).
-# TODO: Warn when n_students is small (e.g. <100) — stochastic variance
-#       makes calibration estimates unreliable at low N.
 CALIBRATION_DATA: tuple[CalibrationPoint, ...] = (
     # 1-semester sweep across dropout_base_rate values
     CalibrationPoint(1, 0.20, 0.278, 500, 5),

--- a/synthed/data_output/exporter.py
+++ b/synthed/data_output/exporter.py
@@ -57,6 +57,7 @@ class DataExporter:
         perceived_cost_benefit reflect the student's initial state before
         simulation. For evolved/final values, see outcomes.csv.
         """
+        self._ensure_output_dir()
         filepath = self.output_dir / "students.csv"
         fieldnames = [
             # Identity
@@ -131,6 +132,7 @@ class DataExporter:
         self, records: list[InteractionRecord],
         display_id_map: dict[str, str] | None = None,
     ) -> str:
+        self._ensure_output_dir()
         filepath = self.output_dir / "interactions.csv"
         _display_map = display_id_map or {}
         fieldnames = [
@@ -161,6 +163,7 @@ class DataExporter:
         self, students: list[StudentPersona], states: dict[str, SimulationState],
         network: SocialNetwork | None = None,
     ) -> str:
+        self._ensure_output_dir()
         filepath = self.output_dir / "outcomes.csv"
         fieldnames = [
             "student_id", "display_id", "has_dropped_out", "dropout_week", "withdrawal_reason", "final_dropout_phase",
@@ -224,6 +227,7 @@ class DataExporter:
     def export_weekly_engagement(
         self, students: list[StudentPersona], states: dict[str, SimulationState],
     ) -> str:
+        self._ensure_output_dir()
         filepath = self.output_dir / "weekly_engagement.csv"
         max_weeks = max((len(s.weekly_engagement_history) for s in states.values()), default=0)
         fieldnames = ["student_id", "display_id"] + [f"week_{w}" for w in range(1, max_weeks + 1)]

--- a/synthed/data_output/exporter.py
+++ b/synthed/data_output/exporter.py
@@ -26,8 +26,13 @@ class DataExporter:
     4. weekly_engagement.csv — Week-by-week engagement trajectories
     """
 
-    def __init__(self, output_dir: str = "./output"):
-        self.output_dir = Path(output_dir)
+    def __init__(self, output_dir: str | None = "./output"):
+        self.output_dir = Path(output_dir) if output_dir is not None else None
+
+    def _ensure_output_dir(self) -> None:
+        """Create the output directory if it does not yet exist."""
+        if self.output_dir is None:
+            raise RuntimeError("DataExporter.output_dir is None — cannot write files")
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
     def export_all(
@@ -36,6 +41,7 @@ class DataExporter:
         states: dict[str, SimulationState],
         network: SocialNetwork | None = None,
     ) -> dict[str, str]:
+        self._ensure_output_dir()
         paths = {}
         display_id_map = {s.id: s.display_id for s in students}
         paths["students"] = self.export_students(students)

--- a/synthed/pipeline.py
+++ b/synthed/pipeline.py
@@ -54,7 +54,7 @@ class SynthEdPipeline:
         environment: ODLEnvironment | None = None,
         institutional_config: InstitutionalConfig | None = None,
         reference_stats: ReferenceStatistics | None = None,
-        output_dir: str = "./output",
+        output_dir: str | None = "./output",
         llm_model: str = "gpt-4o-mini",
         llm_base_url: str | None = None,
         use_llm: bool = False,
@@ -74,7 +74,7 @@ class SynthEdPipeline:
         self.institutional_config = institutional_config or InstitutionalConfig()
         self.grading_config = grading_config or GradingConfig()
         self.reference = reference_stats or ReferenceStatistics()
-        self.output_dir = Path(output_dir)
+        self.output_dir = Path(output_dir) if output_dir is not None else None
         self.use_llm = use_llm
         self.seed = seed
         self.n_semesters = n_semesters
@@ -102,7 +102,9 @@ class SynthEdPipeline:
             grading_config=self.grading_config,
             engine_config=engine_config,
         )
-        self.exporter = DataExporter(output_dir=str(self.output_dir))
+        self.exporter = DataExporter(
+            output_dir=str(self.output_dir) if self.output_dir is not None else None
+        )
         self.validator = SyntheticDataValidator(reference=self.reference)
 
     def _apply_calibration(
@@ -233,6 +235,14 @@ class SynthEdPipeline:
         """
         if not isinstance(n_students, int) or n_students <= 0:
             raise ValueError(f"n_students must be a positive integer, got {n_students}")
+
+        if n_students < 100:
+            logger.warning(
+                "n_students=%d is small — stochastic variance may make "
+                "calibration and validation results unreliable. "
+                "Consider n_students >= 100 for stable results.",
+                n_students,
+            )
 
         report: dict[str, Any] = {
             "pipeline": f"SynthEd v{__version__}",
@@ -408,14 +418,17 @@ class SynthEdPipeline:
                     validation_report['summary']['passed'],
                     validation_report['summary']['total_tests'])
 
-        # Save full report
-        report_path = self.output_dir / "pipeline_report.json"
-        report_path.write_text(json.dumps(report, indent=2, default=str))
-        report["report_path"] = str(report_path)
+        # Save full report (skipped in calibration mode when no output dir)
+        if self.output_dir is not None:
+            report_path = self.output_dir / "pipeline_report.json"
+            report_path.write_text(json.dumps(report, indent=2, default=str))
+            report["report_path"] = str(report_path)
+            logger.info("Pipeline complete. Report saved to %s", report_path)
+        else:
+            logger.info("Pipeline complete (calibration mode — no report written to disk)")
 
         # LLM cost report
         if self.llm:
             report["llm_costs"] = self.llm.cost_report()
 
-        logger.info("Pipeline complete. Report saved to %s", report_path)
         return report

--- a/synthed/pipeline.py
+++ b/synthed/pipeline.py
@@ -27,7 +27,7 @@ from .simulation.grading import GradingConfig
 from .simulation.institutional import InstitutionalConfig
 from .data_output.exporter import DataExporter
 from .data_output.oulad_exporter import OuladExporter
-from .validation.validator import SyntheticDataValidator, ReferenceStatistics
+from .validation import SyntheticDataValidator, ReferenceStatistics
 from .utils.llm import LLMClient
 
 logger = logging.getLogger(__name__)
@@ -112,11 +112,7 @@ class SynthEdPipeline:
         target_range: tuple[float, float],
         n_semesters: int,
     ) -> None:
-        """Use CalibrationMap to set dropout_base_rate from target dropout range.
-
-        TODO: Warn when n_students < 100 — stochastic variance makes
-              calibration estimates unreliable at small population sizes.
-        """
+        """Use CalibrationMap to set dropout_base_rate from target dropout range."""
         calibration_map = CalibrationMap()
         estimate = calibration_map.estimate_from_range(target_range, n_semesters)
         self._calibration_estimate = estimate

--- a/synthed/simulation/environment.py
+++ b/synthed/simulation/environment.py
@@ -69,6 +69,7 @@ class ODLEnvironment:
             self.scheduled_events = self._default_events()
         if not self.positive_events:
             self.positive_events = self._default_positive_events()
+        self._course_index: dict[str, Course] = {c.id: c for c in self.courses}
 
     def _default_courses(self) -> list[Course]:
         """Generate a default set of ODL courses."""
@@ -145,7 +146,4 @@ class ODLEnvironment:
         }
 
     def get_course_by_id(self, course_id: str) -> Course | None:
-        for c in self.courses:
-            if c.id == course_id:
-                return c
-        return None
+        return self._course_index.get(course_id)

--- a/synthed/validation/__init__.py
+++ b/synthed/validation/__init__.py
@@ -1,3 +1,4 @@
+from .types import ReferenceStatistics, ValidationResult
 from .validator import SyntheticDataValidator
 
-__all__ = ["SyntheticDataValidator"]
+__all__ = ["SyntheticDataValidator", "ReferenceStatistics", "ValidationResult"]

--- a/synthed/validation/types.py
+++ b/synthed/validation/types.py
@@ -1,0 +1,71 @@
+"""
+Shared type definitions for the validation package.
+
+ReferenceStatistics and ValidationResult are defined here so they can be
+imported by external callers without pulling in the full validator module.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class ReferenceStatistics:
+    """
+    Real-world reference statistics for validation.
+
+    Users provide aggregate statistics from their institution (no individual
+    data needed). These are used to assess how well synthetic data matches
+    the target population.
+    """
+    # Demographics
+    age_mean: float = 28.0
+    age_std: float = 8.0
+    gender_distribution: dict[str, float] = field(
+        default_factory=lambda: {"male": 0.48, "female": 0.52}
+    )
+    employment_rate: float = 0.78
+
+    # Academic
+    gpa_mean: float = 2.3
+    gpa_std: float = 0.8
+    dropout_rate: float = 0.43
+    dropout_range: tuple[float, float] | None = (0.35, 0.55)
+
+    # Grading outcomes
+    pass_rate: float | None = None
+    distinction_rate: float | None = None
+
+    # Engagement (if available)
+    avg_weekly_logins: float | None = None
+    avg_forum_posts_per_student: float | None = None
+
+    def __post_init__(self):
+        if self.dropout_range is not None:
+            lo, hi = self.dropout_range
+            if not (0.0 < lo < hi < 1.0):
+                raise ValueError(
+                    f"dropout_range must satisfy 0 < lower < upper < 1, "
+                    f"got {self.dropout_range}"
+                )
+
+    @classmethod
+    def from_json(cls, filepath: str) -> ReferenceStatistics:
+        data = json.loads(Path(filepath).read_text())
+        return cls(**data)
+
+
+@dataclass
+class ValidationResult:
+    """Result of a single validation test."""
+    test_name: str
+    metric: str
+    synthetic_value: float
+    reference_value: float | None
+    statistic: float | None = None
+    p_value: float | None = None
+    passed: bool = True
+    details: str = ""

--- a/synthed/validation/validator.py
+++ b/synthed/validation/validator.py
@@ -8,72 +8,12 @@ coherence checks and privacy guarantees.
 
 from __future__ import annotations
 
-import json
-from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any
 
 import numpy as np
 from scipy import stats
 
-
-@dataclass
-class ReferenceStatistics:
-    """
-    Real-world reference statistics for validation.
-
-    Users provide aggregate statistics from their institution (no individual
-    data needed). These are used to assess how well synthetic data matches
-    the target population.
-    """
-    # Demographics
-    age_mean: float = 28.0
-    age_std: float = 8.0
-    gender_distribution: dict[str, float] = field(
-        default_factory=lambda: {"male": 0.48, "female": 0.52}
-    )
-    employment_rate: float = 0.78
-
-    # Academic
-    gpa_mean: float = 2.3
-    gpa_std: float = 0.8
-    dropout_rate: float = 0.43
-    dropout_range: tuple[float, float] | None = (0.35, 0.55)
-
-    # Grading outcomes
-    pass_rate: float | None = None
-    distinction_rate: float | None = None
-
-    # Engagement (if available)
-    avg_weekly_logins: float | None = None
-    avg_forum_posts_per_student: float | None = None
-
-    def __post_init__(self):
-        if self.dropout_range is not None:
-            lo, hi = self.dropout_range
-            if not (0.0 < lo < hi < 1.0):
-                raise ValueError(
-                    f"dropout_range must satisfy 0 < lower < upper < 1, "
-                    f"got {self.dropout_range}"
-                )
-
-    @classmethod
-    def from_json(cls, filepath: str) -> ReferenceStatistics:
-        data = json.loads(Path(filepath).read_text())
-        return cls(**data)
-
-
-@dataclass
-class ValidationResult:
-    """Result of a single validation test."""
-    test_name: str
-    metric: str
-    synthetic_value: float
-    reference_value: float | None
-    statistic: float | None = None
-    p_value: float | None = None
-    passed: bool = True
-    details: str = ""
+from .types import ReferenceStatistics, ValidationResult
 
 
 class SyntheticDataValidator:

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -27,3 +27,23 @@ class TestODLEnvironment:
         assert course is not None
         assert course.name == "Introduction to Computer Science"
         assert env.get_course_by_id("NONEXIST") is None
+
+    def test_get_course_by_id_returns_correct_course(self):
+        env = ODLEnvironment()
+        course = env.get_course_by_id("MATH201")
+        assert course is not None
+        assert course.id == "MATH201"
+        assert course.name == "Statistics for Social Sciences"
+
+    def test_course_index_exists(self):
+        env = ODLEnvironment()
+        assert hasattr(env, "_course_index")
+        assert isinstance(env._course_index, dict)
+        assert len(env._course_index) == len(env.courses)
+        for c in env.courses:
+            assert c.id in env._course_index
+
+    def test_get_course_by_id_nonexistent_returns_none(self):
+        env = ODLEnvironment()
+        assert env.get_course_by_id("DOES_NOT_EXIST") is None
+        assert env.get_course_by_id("") is None

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -1,5 +1,6 @@
 """Integration tests for the SynthEdPipeline."""
 
+import logging
 import pytest
 
 from synthed.pipeline import SynthEdPipeline
@@ -126,3 +127,26 @@ class TestPipelineMultiSemesterInterim:
         report = pipeline.run(n_students=20)
         # No target_dropout_range => no interim reports
         assert "interim_reports" not in report
+
+
+class TestSmallNWarning:
+    """Tests for small n_students warning (P8)."""
+
+    def test_small_n_emits_warning(self, tmp_path, caplog):
+        """Running with n_students < 100 must emit a warning via the pipeline logger."""
+        pipeline = SynthEdPipeline(output_dir=str(tmp_path), seed=42)
+        with caplog.at_level(logging.WARNING, logger="synthed.pipeline"):
+            pipeline.run(n_students=30)
+        warning_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("n_students=30" in msg and "small" in msg for msg in warning_messages)
+
+    def test_no_warning_for_large_n(self, tmp_path, caplog):
+        """Running with n_students >= 100 must NOT emit a small-n warning."""
+        pipeline = SynthEdPipeline(output_dir=str(tmp_path), seed=42)
+        with caplog.at_level(logging.WARNING, logger="synthed.pipeline"):
+            pipeline.run(n_students=100)
+        small_n_warnings = [
+            r for r in caplog.records
+            if "small" in r.getMessage() and "n_students" in r.getMessage()
+        ]
+        assert len(small_n_warnings) == 0

--- a/tests/test_sobol.py
+++ b/tests/test_sobol.py
@@ -323,3 +323,43 @@ class TestSobolIntegration:
 
         # Higher risk multiplier should produce more dropouts
         assert result_high["dropout_rate"] >= result_low["dropout_rate"]
+
+
+class TestSimRunnerCalibrationMode:
+    """Tests for calibration_mode=True skipping temp directory creation."""
+
+    def test_calibration_mode_does_not_create_tmpdir(self):
+        """tempfile.mkdtemp must NOT be called when calibration_mode=True."""
+        from unittest.mock import patch
+        from synthed.agents.persona import PersonaConfig
+        from synthed.analysis._sim_runner import run_simulation_with_overrides
+
+        default_config = PersonaConfig()
+        with patch("synthed.analysis._sim_runner.tempfile.mkdtemp") as mock_mkdtemp:
+            run_simulation_with_overrides(
+                {},
+                n_students=20,
+                seed=42,
+                default_config=default_config,
+                calibration_mode=True,
+            )
+        mock_mkdtemp.assert_not_called()
+
+    def test_calibration_mode_returns_expected_keys(self):
+        """calibration_mode=True run returns same dict structure as normal run."""
+        from synthed.agents.persona import PersonaConfig
+        from synthed.analysis._sim_runner import run_simulation_with_overrides
+
+        default_config = PersonaConfig()
+        result = run_simulation_with_overrides(
+            {},
+            n_students=20,
+            seed=42,
+            default_config=default_config,
+            calibration_mode=True,
+        )
+        expected_keys = {
+            "dropout_rate", "mean_engagement", "mean_gpa",
+            "std_engagement", "pass_rate", "distinction_rate", "fail_rate",
+        }
+        assert expected_keys == set(result.keys())

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,6 +1,6 @@
 """Tests for SyntheticDataValidator."""
 
-from synthed.validation.validator import SyntheticDataValidator, ReferenceStatistics
+from synthed.validation import SyntheticDataValidator, ReferenceStatistics
 
 
 class TestSyntheticDataValidator:


### PR DESCRIPTION
## Summary
- **P4:** O(1) dict index for `get_course_by_id` (was O(n) linear scan)
- **P6:** Skip temp dir creation in calibration mode (I/O reduction for NSGA-II/Sobol)
- **P7:** Extract `ReferenceStatistics` + `ValidationResult` to `validation/types.py` (validator.py 758→700 lines)
- **P8:** Warning when `n_students < 100` for calibration reliability

## Test plan
- [x] 642 tests pass (7 new)
- [x] Determinism preserved: seed=42, n=50 → dropout=0.580000, gpa=2.829580, engagement=0.153985
- [x] ruff clean
- [x] doc_facts consistent
- [x] Code review: DRY fix, lazy mkdir guard, stale TODOs removed, imports canonicalized

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added warning when running with fewer than 100 students, indicating reduced reliability for calibration and validation results.

* **Performance**
  * Optimized course lookup from linear scan to constant-time operation.
  * Calibration mode now skips temporary directory creation.

* **Documentation**
  * Updated test suite metrics documenting expanded coverage (642 tests across 39 files).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->