### PR TITLE
feat: Sobol parallel execution via n_workers (P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to SynthEd are documented here.
 
 ### Added
 - Warning when `n_students < 100` (calibration reliability)
+- `SobolAnalyzer` parallel execution via `n_workers` parameter (ProcessPoolExecutor)
 
 ## [1.2.0] - 2026-04-05
 

--- a/docs/THEORY.md
+++ b/docs/THEORY.md
@@ -183,7 +183,7 @@ SynthEd/
 │   │   └── validation.py        # Input validation utilities
 │   ├── calibration.py           # CalibrationMap: target dropout -> params
 │   └── pipeline.py              # End-to-end orchestrator
-├── tests/                       # 642 pytest tests across 39 files
+├── tests/                       # 645 pytest tests across 39 files
 ├── docs/
 │   ├── GUIDE.md                 # User guide
 │   └── THEORY.md                # This file
@@ -212,7 +212,7 @@ Quality grades: **A** (90%+), **B** (75%+), **C** (60%+), **D** (40%+), **F** (<
 
 ## 🧪 Test Suite
 
-642 pytest tests across 39 files:
+645 pytest tests across 39 files:
 
 | Test File | Tests | Coverage |
 |-----------|-------|----------|

--- a/run_calibration.py
+++ b/run_calibration.py
@@ -29,11 +29,11 @@ PROFILE_NAMES = ["default"]
 OUTPUT_DIR = Path("calibration_output")
 
 
-def run_sobol(n_students: int, seed: int) -> list[SobolRanking]:
+def run_sobol(n_students: int, seed: int, n_workers: int = 1) -> list[SobolRanking]:
     """Run single Sobol analysis and return dropout rankings."""
-    logger.info("Running Sobol analysis (n_students=%d)...", n_students)
+    logger.info("Running Sobol analysis (n_students=%d, n_workers=%d)...", n_students, n_workers)
     t0 = time.time()
-    analyzer = SobolAnalyzer(n_students=n_students, seed=seed)
+    analyzer = SobolAnalyzer(n_students=n_students, seed=seed, n_workers=n_workers)
     results = analyzer.run()
     dropout_result = next(r for r in results if r.metric == "dropout_rate")
     rankings = analyzer.rank(dropout_result)
@@ -129,7 +129,7 @@ def main():
     OUTPUT_DIR.mkdir(exist_ok=True)
 
     # Step 1: Sobol (once)
-    rankings = run_sobol(n_students=n_students, seed=args.seed)
+    rankings = run_sobol(n_students=n_students, seed=args.seed, n_workers=args.workers)
 
     # Step 2: Calibrate each profile
     cal = NSGAIICalibrator(n_students=n_students, seed=args.seed, n_workers=args.workers)

--- a/synthed/analysis/sobol_sensitivity.py
+++ b/synthed/analysis/sobol_sensitivity.py
@@ -219,13 +219,15 @@ class SobolAnalyzer:
 
     def __init__(
         self,
+        parameters: tuple[SobolParameter, ...] | None = None,
         n_students: int = 200,
         seed: int = 42,
-        parameters: tuple[SobolParameter, ...] | None = None,
+        n_workers: int = 1,
     ):
         self.n_students = n_students
         self.seed = seed
         self.parameters = parameters or SOBOL_PARAMETER_SPACE
+        self._n_workers = max(1, n_workers)
         self._problem = self._build_problem()
         self._default_config = PersonaConfig()  # cached to avoid repeated construction
         self._validate_parameters()
@@ -381,19 +383,54 @@ class SobolAnalyzer:
 
     def _run_simulations(self, samples: np.ndarray) -> list[dict]:
         """Run one simulation per sample row, collecting output metrics."""
-        outputs = []
         n_total = len(samples)
-        log_interval = max(1, n_total // 20)  # log every 5%
+        log_interval = max(1, n_total // 20)
 
-        for i, row in enumerate(samples):
-            overrides = dict(zip(self._problem["names"], row))
-            result = run_simulation_with_overrides(
-                overrides, self.n_students, self.seed, self._default_config,
-            )
-            outputs.append(result)
+        override_list = [
+            dict(zip(self._problem["names"], row)) for row in samples
+        ]
 
-            if (i + 1) % log_interval == 0:
-                pct = (i + 1) / n_total * 100
-                logger.info("  Progress: %d/%d (%.0f%%)", i + 1, n_total, pct)
+        if self._n_workers <= 1:
+            # Sequential (deterministic, default)
+            outputs = []
+            for i, overrides in enumerate(override_list):
+                result = run_simulation_with_overrides(
+                    overrides, self.n_students, self.seed, self._default_config,
+                )
+                outputs.append(result)
+                if (i + 1) % log_interval == 0:
+                    logger.info("  Progress: %d/%d (%.0f%%)", i + 1, n_total, (i + 1) / n_total * 100)
+            return outputs
+
+        # Parallel execution (follows nsga2_calibrator._run_parallel pattern)
+        from concurrent.futures import ProcessPoolExecutor, as_completed
+        from functools import partial
+
+        worker = partial(
+            run_simulation_with_overrides,
+            n_students=self.n_students,
+            seed=self.seed,
+            default_config=self._default_config,
+            calibration_mode=True,
+        )
+
+        logger.info("Running %d simulations with %d workers...", n_total, self._n_workers)
+        outputs: list[dict | None] = [None] * n_total
+
+        pool = ProcessPoolExecutor(max_workers=self._n_workers)
+        try:
+            future_to_idx = {
+                pool.submit(worker, overrides=od): i
+                for i, od in enumerate(override_list)
+            }
+            completed = 0
+            for future in as_completed(future_to_idx):
+                idx = future_to_idx[future]
+                outputs[idx] = future.result()
+                completed += 1
+                if completed % log_interval == 0:
+                    logger.info("  Progress: %d/%d (%.0f%%)", completed, n_total, completed / n_total * 100)
+        finally:
+            pool.shutdown(wait=False, cancel_futures=True)
 
         return outputs

--- a/tests/test_sobol.py
+++ b/tests/test_sobol.py
@@ -325,6 +325,28 @@ class TestSobolIntegration:
         assert result_high["dropout_rate"] >= result_low["dropout_rate"]
 
 
+# ─────────────────────────────────────────────
+# n_workers parameter tests
+# ─────────────────────────────────────────────
+
+class TestNWorkers:
+    def test_sobol_accepts_n_workers_param(self):
+        from synthed.analysis.sobol_sensitivity import SobolAnalyzer, SOBOL_PARAMETER_SPACE
+        analyzer = SobolAnalyzer(parameters=SOBOL_PARAMETER_SPACE[:3], n_students=10, seed=42, n_workers=2)
+        assert analyzer._n_workers == 2
+
+    def test_sobol_default_n_workers_is_one(self):
+        from synthed.analysis.sobol_sensitivity import SobolAnalyzer, SOBOL_PARAMETER_SPACE
+        analyzer = SobolAnalyzer(parameters=SOBOL_PARAMETER_SPACE[:3], n_students=10, seed=42)
+        assert analyzer._n_workers == 1
+
+    def test_sobol_n_workers_clamped_to_one(self):
+        """n_workers <= 0 is clamped to 1 by max(1, n_workers)."""
+        from synthed.analysis.sobol_sensitivity import SobolAnalyzer, SOBOL_PARAMETER_SPACE
+        analyzer = SobolAnalyzer(parameters=SOBOL_PARAMETER_SPACE[:3], n_students=10, seed=42, n_workers=0)
+        assert analyzer._n_workers == 1
+
+
 class TestSimRunnerCalibrationMode:
     """Tests for calibration_mode=True skipping temp directory creation."""
 


### PR DESCRIPTION
## Summary
- **P1:** Add `n_workers` parameter to `SobolAnalyzer` for ProcessPoolExecutor parallelization
- Follows proven pattern from `nsga2_calibrator._run_parallel`
- Default `n_workers=1` preserves sequential deterministic behavior
- `--workers` CLI flag now controls both NSGA-II and Sobol

## Test plan
- [x] 645 tests pass (3 new)
- [x] Determinism preserved with n_workers=1
- [x] ruff clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sobol sensitivity analysis now supports parallel execution with a configurable workers parameter, enabling faster computation on multi-core systems. Defaults to single-threaded execution for backward compatibility.

* **Tests**
  * Added validation tests for parallel execution configuration, including default values and boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->