### PR TITLE
feat: wire grading_method=relative into simulation engine (Roadmap #2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,14 @@ All notable changes to SynthEd are documented here.
 - `SimulationEngine._simulate_student_week` split into 5 focused methods (lms, forum, assignment, live_session, exam)
 - `SynthEdPipeline._prepare_validation_data` extracted from `run()`
 - `_validate_correlations`: 9 standard tests extracted into declarative table via `_correlation_test` helper
+- `_assign_outcomes` refactored into dispatcher with `_assign_outcomes_absolute` and `_assign_outcomes_relative`
 
 ### Added
 - Warning when `n_students < 100` (calibration reliability)
 - `SobolAnalyzer` parallel execution via `n_workers` parameter (ProcessPoolExecutor)
+- `grading_method="relative"` support in SimulationEngine — t-score standardization with cohort-relative outcome classification
+- `normalize_t_scores()` utility for t-score to 0-1 conversion
+- Fallback to absolute grading for small cohorts (n<2) or zero-variance scenarios
 
 ## [1.2.0] - 2026-04-05
 

--- a/docs/THEORY.md
+++ b/docs/THEORY.md
@@ -183,7 +183,7 @@ SynthEd/
 │   │   └── validation.py        # Input validation utilities
 │   ├── calibration.py           # CalibrationMap: target dropout -> params
 │   └── pipeline.py              # End-to-end orchestrator
-├── tests/                       # 645 pytest tests across 39 files
+├── tests/                       # 655 pytest tests across 39 files
 ├── docs/
 │   ├── GUIDE.md                 # User guide
 │   └── THEORY.md                # This file
@@ -212,7 +212,7 @@ Quality grades: **A** (90%+), **B** (75%+), **C** (60%+), **D** (40%+), **F** (<
 
 ## 🧪 Test Suite
 
-645 pytest tests across 39 files:
+655 pytest tests across 39 files:
 
 | Test File | Tests | Coverage |
 |-----------|-------|----------|

--- a/synthed/simulation/engine.py
+++ b/synthed/simulation/engine.py
@@ -367,60 +367,18 @@ class SimulationEngine:
         else:
             self._assign_outcomes_absolute(states)
 
-    def _assign_outcomes_absolute(self, states: dict[str, SimulationState]) -> None:
-        """Assign semester_grade and outcome using absolute grading.
+    def _filter_eligible_states(
+        self,
+        states: dict[str, SimulationState],
+        cfg: GradingConfig,
+        floor: float,
+    ) -> dict[str, float]:
+        """Compute semester_grade and filter eligible students.
 
-        Thresholds (pass_threshold, distinction_threshold, component_pass_thresholds)
-        are on the transcript scale (floor-adjusted). Raw quality is converted via
-        ``floor + (1 - floor) * raw`` before comparison.
+        Sets outcome for ineligible students (Withdrawn, Fail).
+        Returns dict of sid -> raw [0-1] semester_grade, NOT floor-adjusted.
         """
-        cfg = self.grading_config
-        floor = cfg.grade_floor
-        for state in states.values():
-            if state.has_dropped_out:
-                state.outcome = "Withdrawn"
-                continue
-            if state.gpa_count == 0:
-                state.outcome = "Fail"
-                continue
-
-            # Exam eligibility check (on floor-adjusted scale)
-            if cfg.exam_eligibility_threshold is not None:
-                midterm_agg = self._compute_midterm_aggregate(state, cfg)
-                adjusted_midterm = floor + (1.0 - floor) * midterm_agg
-                if adjusted_midterm < cfg.exam_eligibility_threshold:
-                    state.outcome = "Fail"
-                    continue
-
-            state.semester_grade = calculate_semester_grade(
-                cfg,
-                midterm_exam_scores=state.midterm_exam_scores,
-                assignment_scores=state.assignment_scores,
-                forum_scores=state.forum_scores,
-                final_score=state.final_score,
-                n_total_assignments=state.n_total_assignments,
-                n_total_forums=state.n_total_forums,
-            )
-
-            if state.semester_grade is not None:
-                state.outcome = self._classify_absolute_single(
-                    state, cfg, floor, state.semester_grade,
-                )
-            else:
-                state.outcome = "Fail"
-
-    def _assign_outcomes_relative(self, states: dict[str, SimulationState]) -> None:
-        """Assign semester_grade and outcome using relative (t-score) grading.
-
-        Pass 1: compute semester_grade for all eligible students.
-        Pass 2: apply t-score standardization and classify using normalized scores.
-        Falls back to absolute if fewer than 2 eligible or zero variance.
-        """
-        cfg = self.grading_config
-        floor = cfg.grade_floor
-
-        # Pass 1: compute semester_grade for all eligible students
-        eligible: dict[str, float] = {}  # values are raw [0-1] semester_grade, NOT floor-adjusted
+        eligible: dict[str, float] = {}
         for sid, state in states.items():
             if state.has_dropped_out:
                 state.outcome = "Withdrawn"
@@ -428,15 +386,12 @@ class SimulationEngine:
             if state.gpa_count == 0:
                 state.outcome = "Fail"
                 continue
-
-            # Exam eligibility check (same as absolute)
             if cfg.exam_eligibility_threshold is not None:
                 midterm_agg = self._compute_midterm_aggregate(state, cfg)
                 adjusted_midterm = floor + (1.0 - floor) * midterm_agg
                 if adjusted_midterm < cfg.exam_eligibility_threshold:
                     state.outcome = "Fail"
                     continue
-
             grade = calculate_semester_grade(
                 cfg,
                 midterm_exam_scores=state.midterm_exam_scores,
@@ -451,43 +406,19 @@ class SimulationEngine:
                 eligible[sid] = grade
             else:
                 state.outcome = "Fail"
+        return eligible
 
-        # Fallback: if fewer than 2 eligible, use absolute
-        if len(eligible) < 2:
-            logger.warning(
-                "Relative grading: fewer than 2 eligible students, "
-                "falling back to absolute",
-            )
-            for sid, grade in eligible.items():
-                state = states[sid]
-                state.outcome = self._classify_absolute_single(
-                    state, cfg, floor, grade,
-                )
-            return
-
-        # Pass 2: apply t-score standardization
-        sids = list(eligible.keys())
-        raw_grades = [eligible[sid] for sid in sids]
-        t_scores = apply_relative_grading(raw_grades)
-        normalized = normalize_t_scores(t_scores)
-
-        # Zero-variance check (all t_scores = 50.0 means std was ~0)
-        if all(abs(t - 50.0) < 1e-9 for t in t_scores):
-            logger.warning(
-                "Relative grading: zero variance in semester grades, "
-                "falling back to absolute",
-            )
-            for sid, grade in eligible.items():
-                state = states[sid]
-                state.outcome = self._classify_absolute_single(
-                    state, cfg, floor, grade,
-                )
-            return
-
-        # Classify using normalized t-scores
+    def _classify_relative(
+        self,
+        states: dict[str, SimulationState],
+        cfg: GradingConfig,
+        floor: float,
+        sids: list[str],
+        normalized: list[float],
+    ) -> None:
+        """Classify students using normalized t-scores with dual-hurdle check."""
         for sid, norm_score in zip(sids, normalized, strict=True):
             state = states[sid]
-            # Dual-hurdle still checks floor-adjusted components (absolute)
             midterm_agg = self._compute_midterm_aggregate(state, cfg)
             adjusted_midterm = floor + (1.0 - floor) * midterm_agg
             adjusted_final = (
@@ -502,6 +433,60 @@ class SimulationEngine:
                 state.outcome = _classify_outcome(norm_score, cfg)
             else:
                 state.outcome = "Fail"
+
+    def _assign_outcomes_absolute(self, states: dict[str, SimulationState]) -> None:
+        """Assign semester_grade and outcome using absolute grading.
+
+        Thresholds (pass_threshold, distinction_threshold, component_pass_thresholds)
+        are on the transcript scale (floor-adjusted). Raw quality is converted via
+        ``floor + (1 - floor) * raw`` before comparison.
+        """
+        cfg = self.grading_config
+        floor = cfg.grade_floor
+        eligible = self._filter_eligible_states(states, cfg, floor)
+        for sid, grade in eligible.items():
+            states[sid].outcome = self._classify_absolute_single(
+                states[sid], cfg, floor, grade,
+            )
+
+    def _assign_outcomes_relative(self, states: dict[str, SimulationState]) -> None:
+        """Assign semester_grade and outcome using relative (t-score) grading.
+
+        Applies t-score standardization and classifies using normalized scores.
+        Falls back to absolute if fewer than 2 eligible or zero variance.
+        """
+        cfg = self.grading_config
+        floor = cfg.grade_floor
+        eligible = self._filter_eligible_states(states, cfg, floor)
+
+        if len(eligible) < 2:
+            logger.warning(
+                "Relative grading: fewer than 2 eligible students, "
+                "falling back to absolute",
+            )
+            for sid, grade in eligible.items():
+                states[sid].outcome = self._classify_absolute_single(
+                    states[sid], cfg, floor, grade,
+                )
+            return
+
+        sids = list(eligible.keys())
+        raw_grades = [eligible[sid] for sid in sids]
+        t_scores = apply_relative_grading(raw_grades)
+        normalized = normalize_t_scores(t_scores)
+
+        if all(abs(t - 50.0) < 1e-9 for t in t_scores):
+            logger.warning(
+                "Relative grading: zero variance in semester grades, "
+                "falling back to absolute",
+            )
+            for sid, grade in eligible.items():
+                states[sid].outcome = self._classify_absolute_single(
+                    states[sid], cfg, floor, grade,
+                )
+            return
+
+        self._classify_relative(states, cfg, floor, sids, normalized)
 
     def _simulate_student_week(
         self, student: StudentPersona, state: SimulationState,

--- a/synthed/simulation/engine.py
+++ b/synthed/simulation/engine.py
@@ -420,7 +420,7 @@ class SimulationEngine:
         floor = cfg.grade_floor
 
         # Pass 1: compute semester_grade for all eligible students
-        eligible: dict[str, float] = {}
+        eligible: dict[str, float] = {}  # values are raw [0-1] semester_grade, NOT floor-adjusted
         for sid, state in states.items():
             if state.has_dropped_out:
                 state.outcome = "Withdrawn"
@@ -485,7 +485,7 @@ class SimulationEngine:
             return
 
         # Classify using normalized t-scores
-        for sid, norm_score in zip(sids, normalized):
+        for sid, norm_score in zip(sids, normalized, strict=True):
             state = states[sid]
             # Dual-hurdle still checks floor-adjusted components (absolute)
             midterm_agg = self._compute_midterm_aggregate(state, cfg)

--- a/synthed/simulation/engine.py
+++ b/synthed/simulation/engine.py
@@ -30,9 +30,11 @@ from .engine_config import EngineConfig
 from .environment import ODLEnvironment
 from .grading import (
     GradingConfig,
+    apply_relative_grading,
     calculate_semester_grade,
     check_dual_hurdle_pass,
     classify_outcome as _classify_outcome,
+    normalize_t_scores,
 )
 from .institutional import InstitutionalConfig, scale_by
 from .social_network import SocialNetwork
@@ -334,8 +336,39 @@ class SimulationEngine:
             total += comp_mean * weight
         return total
 
+    def _classify_absolute_single(
+        self, state: SimulationState, cfg: GradingConfig, floor: float,
+        grade: float,
+    ) -> str:
+        """Classify a single student using absolute grading (floor-adjust + hurdle + classify).
+
+        Returns the outcome string: Distinction, Pass, or Fail.
+        """
+        adjusted_grade = floor + (1.0 - floor) * grade
+        midterm_agg = self._compute_midterm_aggregate(state, cfg)
+        adjusted_midterm = floor + (1.0 - floor) * midterm_agg
+        adjusted_final = (
+            (floor + (1.0 - floor) * state.final_score)
+            if state.final_score is not None
+            else None
+        )
+        passes_hurdle = check_dual_hurdle_pass(cfg, adjusted_midterm, adjusted_final)
+        if passes_hurdle:
+            return _classify_outcome(adjusted_grade, cfg)
+        return "Fail"
+
     def _assign_outcomes(self, states: dict[str, SimulationState]) -> None:
         """Assign semester_grade and outcome to each student at end of run.
+
+        Dispatches to absolute or relative grading based on grading_config.
+        """
+        if self.grading_config.grading_method == "relative":
+            self._assign_outcomes_relative(states)
+        else:
+            self._assign_outcomes_absolute(states)
+
+    def _assign_outcomes_absolute(self, states: dict[str, SimulationState]) -> None:
+        """Assign semester_grade and outcome using absolute grading.
 
         Thresholds (pass_threshold, distinction_threshold, component_pass_thresholds)
         are on the transcript scale (floor-adjusted). Raw quality is converted via
@@ -370,19 +403,103 @@ class SimulationEngine:
             )
 
             if state.semester_grade is not None:
-                # Floor-adjust for classification (thresholds are on transcript scale)
-                adjusted_grade = floor + (1.0 - floor) * state.semester_grade
+                state.outcome = self._classify_absolute_single(
+                    state, cfg, floor, state.semester_grade,
+                )
+            else:
+                state.outcome = "Fail"
 
-                # Dual-hurdle check (also on floor-adjusted scale)
+    def _assign_outcomes_relative(self, states: dict[str, SimulationState]) -> None:
+        """Assign semester_grade and outcome using relative (t-score) grading.
+
+        Pass 1: compute semester_grade for all eligible students.
+        Pass 2: apply t-score standardization and classify using normalized scores.
+        Falls back to absolute if fewer than 2 eligible or zero variance.
+        """
+        cfg = self.grading_config
+        floor = cfg.grade_floor
+
+        # Pass 1: compute semester_grade for all eligible students
+        eligible: dict[str, float] = {}
+        for sid, state in states.items():
+            if state.has_dropped_out:
+                state.outcome = "Withdrawn"
+                continue
+            if state.gpa_count == 0:
+                state.outcome = "Fail"
+                continue
+
+            # Exam eligibility check (same as absolute)
+            if cfg.exam_eligibility_threshold is not None:
                 midterm_agg = self._compute_midterm_aggregate(state, cfg)
                 adjusted_midterm = floor + (1.0 - floor) * midterm_agg
-                adjusted_final = (floor + (1.0 - floor) * state.final_score) if state.final_score is not None else None
-                passes_hurdle = check_dual_hurdle_pass(cfg, adjusted_midterm, adjusted_final)
-
-                if passes_hurdle:
-                    state.outcome = _classify_outcome(adjusted_grade, cfg)
-                else:
+                if adjusted_midterm < cfg.exam_eligibility_threshold:
                     state.outcome = "Fail"
+                    continue
+
+            grade = calculate_semester_grade(
+                cfg,
+                midterm_exam_scores=state.midterm_exam_scores,
+                assignment_scores=state.assignment_scores,
+                forum_scores=state.forum_scores,
+                final_score=state.final_score,
+                n_total_assignments=state.n_total_assignments,
+                n_total_forums=state.n_total_forums,
+            )
+            state.semester_grade = grade
+            if grade is not None:
+                eligible[sid] = grade
+            else:
+                state.outcome = "Fail"
+
+        # Fallback: if fewer than 2 eligible, use absolute
+        if len(eligible) < 2:
+            logger.warning(
+                "Relative grading: fewer than 2 eligible students, "
+                "falling back to absolute",
+            )
+            for sid, grade in eligible.items():
+                state = states[sid]
+                state.outcome = self._classify_absolute_single(
+                    state, cfg, floor, grade,
+                )
+            return
+
+        # Pass 2: apply t-score standardization
+        sids = list(eligible.keys())
+        raw_grades = [eligible[sid] for sid in sids]
+        t_scores = apply_relative_grading(raw_grades)
+        normalized = normalize_t_scores(t_scores)
+
+        # Zero-variance check (all t_scores = 50.0 means std was ~0)
+        if all(abs(t - 50.0) < 1e-9 for t in t_scores):
+            logger.warning(
+                "Relative grading: zero variance in semester grades, "
+                "falling back to absolute",
+            )
+            for sid, grade in eligible.items():
+                state = states[sid]
+                state.outcome = self._classify_absolute_single(
+                    state, cfg, floor, grade,
+                )
+            return
+
+        # Classify using normalized t-scores
+        for sid, norm_score in zip(sids, normalized):
+            state = states[sid]
+            # Dual-hurdle still checks floor-adjusted components (absolute)
+            midterm_agg = self._compute_midterm_aggregate(state, cfg)
+            adjusted_midterm = floor + (1.0 - floor) * midterm_agg
+            adjusted_final = (
+                (floor + (1.0 - floor) * state.final_score)
+                if state.final_score is not None
+                else None
+            )
+            passes_hurdle = check_dual_hurdle_pass(
+                cfg, adjusted_midterm, adjusted_final,
+            )
+            if passes_hurdle:
+                state.outcome = _classify_outcome(norm_score, cfg)
             else:
                 state.outcome = "Fail"
 

--- a/synthed/simulation/grading.py
+++ b/synthed/simulation/grading.py
@@ -190,6 +190,8 @@ def apply_relative_grading(raw_scores: list[float]) -> list[float]:
     """
     if len(raw_scores) < 2:
         return [50.0] * len(raw_scores)
+    if not all(math.isfinite(s) for s in raw_scores):
+        raise ValueError("apply_relative_grading received non-finite score(s)")
     arr = np.array(raw_scores, dtype=float)
     std = float(np.std(arr, ddof=0))  # population std (cohort IS the population)
     if std < 1e-9:
@@ -203,6 +205,9 @@ def apply_relative_grading(raw_scores: list[float]) -> list[float]:
 
 def normalize_t_scores(t_scores: list[float]) -> list[float]:
     """Convert t-scores (0-100) to 0-1 scale for classify_outcome."""
+    for s in t_scores:
+        if not math.isfinite(s):
+            raise ValueError(f"normalize_t_scores received non-finite value: {s!r}")
     return [s / 100.0 for s in t_scores]
 
 

--- a/synthed/simulation/grading.py
+++ b/synthed/simulation/grading.py
@@ -106,8 +106,6 @@ class GradingConfig:
             raise ValueError(f"Invalid missing_policy: '{self.missing_policy}'")
         if self.grading_method not in _VALID_GRADING_METHODS:
             raise ValueError(f"Invalid grading_method: '{self.grading_method}'")
-        if self.grading_method == "relative":
-            raise ValueError("grading_method='relative' is not yet implemented; use 'absolute'")
         # Dual-hurdle consistency
         if self.dual_hurdle and not self.component_pass_thresholds:
             raise ValueError("dual_hurdle=True requires at least one entry in component_pass_thresholds")
@@ -188,8 +186,7 @@ def apply_relative_grading(raw_scores: list[float]) -> list[float]:
     Returns 50.0 for single-student, identical-score, or n<2 cases.
     Warns if n < 30.
 
-    Note: Not wired to engine (grading_method='relative' is rejected).
-    Reserved for future implementation.
+    Used by engine when grading_method='relative'.
     """
     if len(raw_scores) < 2:
         return [50.0] * len(raw_scores)
@@ -202,6 +199,11 @@ def apply_relative_grading(raw_scores: list[float]) -> list[float]:
     mean = float(np.mean(arr))
     t_scores = 50.0 + 10.0 * (arr - mean) / std
     return [float(np.clip(s, 0.0, 100.0)) for s in t_scores]
+
+
+def normalize_t_scores(t_scores: list[float]) -> list[float]:
+    """Convert t-scores (0-100) to 0-1 scale for classify_outcome."""
+    return [s / 100.0 for s in t_scores]
 
 
 def calculate_semester_grade(

--- a/tests/test_engine_grading.py
+++ b/tests/test_engine_grading.py
@@ -1,6 +1,8 @@
 """Engine integration tests for GradingConfig."""
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 
 from synthed.simulation.engine import SimulationEngine, SimulationState
@@ -78,3 +80,224 @@ class TestEngineOutcomes:
         engine = SimulationEngine(ODLEnvironment(), seed=42, grading_config=cfg)
         _, states, _ = engine.run(students)
         assert any(s.gpa_count > 0 for s in states.values())
+
+
+def _make_students(n: int, seed: int = 42):
+    from synthed.agents.factory import StudentFactory
+    from synthed.agents.persona import PersonaConfig
+
+    factory = StudentFactory(PersonaConfig(), seed=seed)
+    return factory.generate_population(n=n)
+
+
+class TestRelativeGrading:
+    def test_relative_grading_produces_outcomes(self):
+        """50 students with relative grading: all outcomes valid."""
+        students = _make_students(50)
+        cfg = GradingConfig(grading_method="relative")
+        engine = SimulationEngine(ODLEnvironment(), seed=42, grading_config=cfg)
+        _, states, _ = engine.run(students)
+        valid = {"Distinction", "Pass", "Fail", "Withdrawn"}
+        for state in states.values():
+            assert state.outcome in valid, f"Unexpected outcome: {state.outcome}"
+
+    def test_relative_changes_outcome_distribution(self):
+        """Same seed, absolute vs relative produce different outcome counts."""
+        students_abs = _make_students(50, seed=42)
+        students_rel = _make_students(50, seed=42)
+
+        engine_abs = SimulationEngine(ODLEnvironment(), seed=42)
+        _, states_abs, _ = engine_abs.run(students_abs)
+
+        cfg_rel = GradingConfig(grading_method="relative")
+        engine_rel = SimulationEngine(ODLEnvironment(), seed=42, grading_config=cfg_rel)
+        _, states_rel, _ = engine_rel.run(students_rel)
+
+        def count_outcomes(states):
+            counts = {"Distinction": 0, "Pass": 0, "Fail": 0, "Withdrawn": 0}
+            for s in states.values():
+                counts[s.outcome] += 1
+            return counts
+
+        abs_counts = count_outcomes(states_abs)
+        rel_counts = count_outcomes(states_rel)
+        # Withdrawn count should be same (dropout is pre-grading, same seed)
+        assert abs_counts["Withdrawn"] == rel_counts["Withdrawn"]
+        # At least one non-Withdrawn category differs
+        non_w = ["Distinction", "Pass", "Fail"]
+        assert any(abs_counts[k] != rel_counts[k] for k in non_w), (
+            f"Expected different distributions: abs={abs_counts}, rel={rel_counts}"
+        )
+
+    def test_relative_preserves_ranking(self):
+        """Higher raw semester_grade maps to higher or equal normalized score."""
+        students = _make_students(50)
+        cfg = GradingConfig(grading_method="relative")
+        engine = SimulationEngine(ODLEnvironment(), seed=42, grading_config=cfg)
+        _, states, _ = engine.run(students)
+
+        eligible = [
+            s for s in states.values()
+            if s.semester_grade is not None and s.outcome != "Withdrawn"
+        ]
+        if len(eligible) < 2:
+            return  # not enough data to test ranking
+
+        from synthed.simulation.grading import apply_relative_grading, normalize_t_scores
+
+        raw = [s.semester_grade for s in eligible]
+        t_scores = apply_relative_grading(raw)
+        normalized = normalize_t_scores(t_scores)
+
+        paired = sorted(zip(raw, normalized), key=lambda x: x[0])
+        for i in range(len(paired) - 1):
+            assert paired[i][1] <= paired[i + 1][1], (
+                f"Ranking violated: raw {paired[i][0]} -> {paired[i][1]} "
+                f"> raw {paired[i + 1][0]} -> {paired[i + 1][1]}"
+            )
+
+    def test_relative_zero_variance_fallback(self, caplog):
+        """All eligible students have identical grades -> fallback warning, outcomes assigned."""
+        # Build states manually with identical semester grades
+        cfg = GradingConfig(grading_method="relative")
+        env = ODLEnvironment()
+        engine = SimulationEngine(env, seed=42, grading_config=cfg)
+
+        states = {}
+        for i in range(5):
+            sid = f"S{i:03d}"
+            state = SimulationState(student_id=sid)
+            state.gpa_count = 1
+            state.assignment_scores = [0.70]
+            state.n_total_assignments = 1
+            state.midterm_exam_scores = [0.70]
+            state.forum_scores = [0.70]
+            state.final_score = 0.70
+            states[sid] = state
+
+        with caplog.at_level(logging.WARNING, logger="synthed.simulation.engine"):
+            engine._assign_outcomes(states)
+
+        assert "zero variance" in caplog.text
+        for state in states.values():
+            assert state.outcome in ("Distinction", "Pass", "Fail")
+        # With identical 0.70 grades, floor-adjusted = 0.835 > distinction=0.73
+        # so all should be Distinction (not all Fail)
+        assert any(s.outcome != "Fail" for s in states.values())
+
+    def test_relative_single_eligible_fallback(self, caplog):
+        """1 eligible + rest withdrawn -> fallback to absolute."""
+        cfg = GradingConfig(grading_method="relative")
+        env = ODLEnvironment()
+        engine = SimulationEngine(env, seed=42, grading_config=cfg)
+
+        states = {}
+        # One eligible student
+        s0 = SimulationState(student_id="S000")
+        s0.gpa_count = 1
+        s0.assignment_scores = [0.80]
+        s0.n_total_assignments = 1
+        s0.midterm_exam_scores = [0.75]
+        s0.forum_scores = [0.70]
+        s0.final_score = 0.80
+        states["S000"] = s0
+
+        # Rest withdrawn
+        for i in range(1, 5):
+            sid = f"S{i:03d}"
+            state = SimulationState(student_id=sid)
+            state.has_dropped_out = True
+            state.dropout_week = 3
+            states[sid] = state
+
+        with caplog.at_level(logging.WARNING, logger="synthed.simulation.engine"):
+            engine._assign_outcomes(states)
+
+        assert "fewer than 2" in caplog.text
+        assert states["S000"].outcome in ("Distinction", "Pass", "Fail")
+        for i in range(1, 5):
+            assert states[f"S{i:03d}"].outcome == "Withdrawn"
+
+    def test_relative_all_withdrawn(self):
+        """All dropped out -> all Withdrawn, no crash."""
+        cfg = GradingConfig(grading_method="relative")
+        env = ODLEnvironment()
+        engine = SimulationEngine(env, seed=42, grading_config=cfg)
+
+        states = {}
+        for i in range(5):
+            sid = f"S{i:03d}"
+            state = SimulationState(student_id=sid)
+            state.has_dropped_out = True
+            state.dropout_week = 2
+            states[sid] = state
+
+        engine._assign_outcomes(states)
+        for state in states.values():
+            assert state.outcome == "Withdrawn"
+
+    def test_relative_dual_hurdle_interaction(self):
+        """High t-score but low component -> still fails hurdle."""
+        cfg = GradingConfig(
+            grading_method="relative",
+            dual_hurdle=True,
+            component_pass_thresholds={"final": 0.70},
+        )
+        env = ODLEnvironment()
+        engine = SimulationEngine(env, seed=42, grading_config=cfg)
+
+        states = {}
+        # Student with high midterm but very low final (fails hurdle)
+        s0 = SimulationState(student_id="S000")
+        s0.gpa_count = 2
+        s0.assignment_scores = [0.90]
+        s0.n_total_assignments = 1
+        s0.midterm_exam_scores = [0.90]
+        s0.forum_scores = [0.85]
+        s0.final_score = 0.10  # very low - below hurdle after floor-adjust
+        states["S000"] = s0
+
+        # Student with decent all-around scores
+        s1 = SimulationState(student_id="S001")
+        s1.gpa_count = 2
+        s1.assignment_scores = [0.60]
+        s1.n_total_assignments = 1
+        s1.midterm_exam_scores = [0.60]
+        s1.forum_scores = [0.60]
+        s1.final_score = 0.60
+        states["S001"] = s1
+
+        # Third student to avoid fallback
+        s2 = SimulationState(student_id="S002")
+        s2.gpa_count = 2
+        s2.assignment_scores = [0.50]
+        s2.n_total_assignments = 1
+        s2.midterm_exam_scores = [0.50]
+        s2.forum_scores = [0.50]
+        s2.final_score = 0.50
+        states["S002"] = s2
+
+        engine._assign_outcomes(states)
+
+        # S000 has highest raw grade but low final -> fails hurdle
+        assert states["S000"].outcome == "Fail"
+
+    def test_relative_determinism(self):
+        """Two identical runs produce identical outcomes (compared by position)."""
+        students = _make_students(50, seed=42)
+
+        cfg1 = GradingConfig(grading_method="relative")
+        engine_1 = SimulationEngine(ODLEnvironment(), seed=42, grading_config=cfg1)
+        _, states_1, _ = engine_1.run(students)
+
+        cfg2 = GradingConfig(grading_method="relative")
+        engine_2 = SimulationEngine(ODLEnvironment(), seed=42, grading_config=cfg2)
+        _, states_2, _ = engine_2.run(students)
+
+        sids_1 = list(states_1.keys())
+        sids_2 = list(states_2.keys())
+        assert sids_1 == sids_2
+        for sid in sids_1:
+            assert states_1[sid].outcome == states_2[sid].outcome
+            if states_1[sid].semester_grade is not None:
+                assert states_1[sid].semester_grade == states_2[sid].semester_grade

--- a/tests/test_grading.py
+++ b/tests/test_grading.py
@@ -13,6 +13,7 @@ from synthed.simulation.grading import (
     classify_outcome,
     compute_grade,
     convert_scale,
+    normalize_t_scores,
     piecewise_gpa,
     sample_base_quality,
 )
@@ -78,9 +79,9 @@ class TestGradingConfig:
         with pytest.raises(ValueError, match="dist_alpha.*dist_beta"):
             GradingConfig(distribution="uniform", dist_alpha=0.8, dist_beta=0.2)
 
-    def test_relative_grading_method_rejected(self):
-        with pytest.raises(ValueError, match="not yet implemented"):
-            GradingConfig(grading_method="relative")
+    def test_relative_grading_method_accepted(self):
+        cfg = GradingConfig(grading_method="relative")
+        assert cfg.grading_method == "relative"
 
     def test_invalid_grading_method_rejected(self):
         with pytest.raises(ValueError, match="Invalid grading_method"):
@@ -213,6 +214,14 @@ class TestRelativeGrading:
         # With ddof=0: std=10.0, T = 50 + 10*(x-50)/10 → [40.0, 60.0]
         # With ddof=1: std=14.14, T ≈ [42.93, 57.07]
         assert abs(adjusted[0] - 40.0) < 0.01  # confirms ddof=0
+
+
+class TestNormalizeTScores:
+    def test_normalize_t_scores_basic(self):
+        assert normalize_t_scores([0, 50, 100]) == [0.0, 0.5, 1.0]
+
+    def test_normalize_t_scores_empty(self):
+        assert normalize_t_scores([]) == []
 
 
 class TestCalculateSemesterGrade:


### PR DESCRIPTION
## Summary
- Wire `grading_method="relative"` into SimulationEngine via two-pass approach in `_assign_outcomes`
- T-score standardization (0-100) normalized to 0-1 for outcome classification
- Fallback to absolute grading for small cohorts (n<2) or zero-variance
- Dual-hurdle checks remain on floor-adjusted absolute scale
- NaN/Inf guards on normalize_t_scores and apply_relative_grading

## Test plan
- [x] 655 tests pass (10 new for relative grading)
- [x] Determinism preserved for absolute mode
- [x] Relative mode produces valid, deterministic outcomes
- [x] Edge cases: zero-variance fallback, single-eligible fallback, all-withdrawn
- [x] Security: NaN/Inf guards prevent silent data corruption
- [x] Spec review: 10/10 compliant
- [x] Security review: 2 HIGH findings fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `grading_method="relative"` using cohort-relative t-score standardization for outcome classification.
  * Automatic fallback to absolute grading when cohorts are too small or variance is zero.

* **Tests**
  * Expanded test coverage from 645 to 655 tests.
  * Added comprehensive relative grading integration tests.

* **Documentation**
  * Updated changelog and project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->