### PR TITLE
fix: clarify near-zero variance fallback wording

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -207,7 +207,7 @@ pipeline = SynthEdPipeline(
 )
 ```
 
-Relative mode applies t-score standardization across the cohort. Students are classified by their standing relative to peers rather than fixed thresholds. Falls back to absolute grading for cohorts smaller than 2 or with zero variance.
+Relative mode applies t-score standardization across the cohort. Students are classified by their standing relative to peers rather than fixed thresholds. Falls back to absolute grading for cohorts smaller than 2 or with zero or near-zero variance (std < 1e-9).
 
 ---
 

--- a/docs/THEORY.md
+++ b/docs/THEORY.md
@@ -143,7 +143,7 @@ Each parameter ranges 0-1 with 0.5 as neutral. The `scale_by()` method applies m
 SynthEd supports two grading methods via `GradingConfig`:
 
 - **Absolute grading** (default): Students are classified against fixed thresholds (`pass_threshold`, `distinction_threshold`).
-- **Relative grading** (`grading_method="relative"`): Applies t-score standardization across the cohort. Students are classified by their standing relative to peers rather than fixed thresholds. Automatically falls back to absolute grading for cohorts smaller than 2 or with zero variance.
+- **Relative grading** (`grading_method="relative"`): Applies t-score standardization across the cohort. Students are classified by their standing relative to peers rather than fixed thresholds. Automatically falls back to absolute grading for cohorts smaller than 2 or with zero or near-zero variance (std < 1e-9).
 
 ---
 


### PR DESCRIPTION
## Summary
- CodeRabbit flagged on PR #47: docs said "zero variance" but implementation uses `std < 1e-9` (near-zero)
- Updated GUIDE.md and THEORY.md to say "zero or near-zero variance (std < 1e-9)"

## Test plan
- [x] doc_facts consistent
- [x] No code changes, docs-only fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify when curve-based relative grading automatically falls back to absolute grading, now specifying the precise variance threshold for more transparent guidance on grading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->