### PR TITLE
feat: modulate Baulke dropout thresholds via InstitutionalConfig SSQ (Roadmap #3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to SynthEd are documented here.
 
 ## [Unreleased]
 
+### Added
+- `InstitutionalConfig.support_services_quality` modulates Baulke dropout phase thresholds via `scale_by()` — 13 thresholds scaled, better institutions produce lower dropout
+
 ### Changed
 - `ODLEnvironment.get_course_by_id`: O(1) dict lookup replaces O(n) linear scan
 - `_sim_runner`: Calibration mode skips temp directory creation (I/O reduction)

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -153,6 +153,8 @@ report = pipeline.run(n_students=300)
 
 All values range 0-1 (default 0.5 = neutral). Values above 0.5 improve student outcomes; below 0.5 degrade them.
 
+`support_services_quality` directly modulates Baulke dropout phase thresholds: higher values make it harder for students to advance toward dropout and easier to recover. At 0.5, all thresholds match the default class constants exactly.
+
 ---
 
 ## 📊 Grading Configuration

--- a/docs/THEORY.md
+++ b/docs/THEORY.md
@@ -80,7 +80,7 @@ SynthEd's persona attributes and simulation mechanics are grounded in eleven est
 | 5 | **Self-Determination Theory** (Deci & Ryan, 1985) | Psychology | Intrinsic/extrinsic motivation and amotivation predict persistence. |
 | 6 | **Community of Inquiry** (Garrison et al., 2000) | Online learning | Three presences (social, cognitive, teaching) co-evolve with Tinto's integration. |
 | 7 | **Rovai's Persistence Model** (2003) | Online/distance learning | Digital literacy, self-regulation, time management as ODE-specific factors. |
-| 8 | **Baulke et al. Phase Model** (2022) | Psychology | 6-phase dropout process: non-fit perception -> thoughts -> deliberation -> info search -> decision. |
+| 8 | **Baulke et al. Phase Model** (2022) | Psychology | 6-phase dropout process: non-fit perception -> thoughts -> deliberation -> info search -> decision. Phase thresholds modulated by `support_services_quality` via `scale_by()`. |
 | 9 | **Epstein & Axtell ABSS** (1996) | Computational social science | Bottom-up emergent behavior: peer networks, engagement contagion, dropout cascades. |
 | 10 | **Academic Exhaustion** (Gonzalez et al., 2025) | Psychology | Exhaustion as mediator between stressors and dropout risk. |
 | 11 | **Unavoidable Withdrawal** | Life-event modeling | Stochastic life events (illness, death, relocation) forcing involuntary withdrawal. |

--- a/docs/THEORY.md
+++ b/docs/THEORY.md
@@ -192,7 +192,7 @@ SynthEd/
 │   │   └── validation.py        # Input validation utilities
 │   ├── calibration.py           # CalibrationMap: target dropout -> params
 │   └── pipeline.py              # End-to-end orchestrator
-├── tests/                       # 655 pytest tests across 39 files
+├── tests/                       # 666 pytest tests across 40 files
 ├── docs/
 │   ├── GUIDE.md                 # User guide
 │   └── THEORY.md                # This file
@@ -221,7 +221,7 @@ Quality grades: **A** (90%+), **B** (75%+), **C** (60%+), **D** (40%+), **F** (<
 
 ## 🧪 Test Suite
 
-655 pytest tests across 39 files:
+666 pytest tests across 40 files:
 
 | Test File | Tests | Coverage |
 |-----------|-------|----------|

--- a/synthed/simulation/engine.py
+++ b/synthed/simulation/engine.py
@@ -293,6 +293,7 @@ class SimulationEngine:
                     student, state, week, self.env,
                     lambda s, st: self.moore.average(s, st, self.env),
                     self.rng,
+                    inst=self.inst,
                 )
 
                 if state.dropout_phase >= 5:

--- a/synthed/simulation/theories/baulke.py
+++ b/synthed/simulation/theories/baulke.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, Callable
 
 import numpy as np
 
+from ..institutional import InstitutionalConfig, scale_by
+
 if TYPE_CHECKING:
     from ...agents.persona import StudentPersona
     from ..engine import SimulationState
@@ -67,6 +69,36 @@ class BaulkeDropoutPhase:
     _IMPACT_PHASE_4: float = -0.4
     _IMPACT_DROPOUT: float = -0.8
 
+    def _modulated_thresholds(self, ssq: float) -> dict[str, float]:
+        """Compute phase-transition thresholds scaled by institutional SSQ.
+
+        All thresholds use ``1.0 - ssq`` (inverted) so that higher SSQ
+        (better institution) produces *lower* numeric thresholds.  For
+        forward thresholds this means the student must be in worse shape
+        to advance toward dropout.  For recovery thresholds a lower bar
+        means the student recovers more easily.  Exhaustion is the sole
+        exception — it uses direct ``ssq`` so better institutions raise
+        the bar for what counts as "exhausted".
+
+        At SSQ = 0.5, every value equals its class constant exactly.
+        """
+        inv = 1.0 - ssq
+        return {
+            "nonfit_eng": scale_by(self._NONFIT_ENG_THRESHOLD, inv),
+            "nonfit_eng_soft": scale_by(self._NONFIT_ENG_SOFT, inv),
+            "phase_1_to_2_eng": scale_by(self._PHASE_1_TO_2_ENG, inv),
+            "phase_1_social": scale_by(self._PHASE_1_SOCIAL_THRESHOLD, inv),
+            "phase_2_to_3_eng": scale_by(self._PHASE_2_TO_3_ENG, inv),
+            "phase_3_to_4_eng": scale_by(self._PHASE_3_TO_4_ENG, inv),
+            "trigger_eng": scale_by(self._TRIGGER_ENG_THRESHOLD, inv),
+            "recovery_1_to_0": scale_by(self._RECOVERY_1_TO_0, inv),
+            "recovery_2_to_1": scale_by(self._RECOVERY_2_TO_1, inv),
+            "recovery_3_to_2": scale_by(self._RECOVERY_3_TO_2, inv),
+            "recovery_4_to_3_eng": scale_by(self._RECOVERY_4_TO_3_ENG, inv),
+            "recovery_4_to_3_cb": scale_by(self._RECOVERY_4_TO_3_CB, inv),
+            "exhaustion": scale_by(self._EXHAUSTION_THRESHOLD, ssq),
+        }
+
     def advance_phase(
         self,
         student: StudentPersona,
@@ -75,6 +107,7 @@ class BaulkeDropoutPhase:
         env: ODLEnvironment,
         avg_td_fn: Callable[[StudentPersona, SimulationState], float],
         rng: np.random.Generator,
+        inst: InstitutionalConfig | None = None,
     ) -> None:
         """
         Advance the dropout phase.
@@ -84,21 +117,31 @@ class BaulkeDropoutPhase:
         2 -> 3: Deliberation -- consciously weighing pros/cons of staying vs leaving
         3 -> 4: Information search -- targeted search for alternative options
         4 -> 5: Final decision -- committed to withdraw
+
+        Parameters
+        ----------
+        inst : InstitutionalConfig | None
+            If provided, ``support_services_quality`` modulates phase
+            transition thresholds via :func:`scale_by`.  At the default
+            SSQ = 0.5 all thresholds equal the class constants exactly.
         """
+        ssq = inst.support_services_quality if inst is not None else 0.5
+        t = self._modulated_thresholds(ssq)
+
         eng = state.current_engagement
         history = state.weekly_engagement_history
         avg_td = avg_td_fn(student, state)
 
-        exhausted = hasattr(state, 'exhaustion') and state.exhaustion.exhaustion_level > self._EXHAUSTION_THRESHOLD
+        exhausted = hasattr(state, 'exhaustion') and state.exhaustion.exhaustion_level > t["exhaustion"]
 
         if state.dropout_phase == 0:
             # Phase 0 -> 1: Non-fit perception
             # Gonzalez: high exhaustion accelerates non-fit perception
-            if (eng < self._NONFIT_ENG_THRESHOLD
-                    or (eng < self._NONFIT_ENG_SOFT and state.coi_state.cognitive_presence < self._NONFIT_COG_THRESHOLD)
-                    or (eng < self._NONFIT_ENG_SOFT and avg_td > self._NONFIT_TD_THRESHOLD)
-                    or (eng < self._NONFIT_ENG_SOFT and exhausted)
-                    or (eng < self._NONFIT_ENG_SOFT
+            if (eng < t["nonfit_eng"]
+                    or (eng < t["nonfit_eng_soft"] and state.coi_state.cognitive_presence < self._NONFIT_COG_THRESHOLD)
+                    or (eng < t["nonfit_eng_soft"] and avg_td > self._NONFIT_TD_THRESHOLD)
+                    or (eng < t["nonfit_eng_soft"] and exhausted)
+                    or (eng < t["nonfit_eng_soft"]
                         and state.perceived_mastery_count >= self._NONFIT_GPA_MIN_ITEMS
                         and state.perceived_mastery < self._NONFIT_MASTERY_THRESHOLD)):
                 state.dropout_phase = 1
@@ -108,14 +151,14 @@ class BaulkeDropoutPhase:
 
         elif state.dropout_phase == 1:
             # Recovery back to 0 (harder in ODL -- fewer re-engagement mechanisms)
-            if eng > self._RECOVERY_1_TO_0:
+            if eng > t["recovery_1_to_0"]:
                 state.dropout_phase = 0
                 state.memory.append({"week": week, "event_type": "recovery",
                                     "details": "Re-engaged with program", "impact": self._IMPACT_RECOVERY_1_TO_0})
             # Phase 1 -> 2: Thoughts of quitting
-            elif (eng < self._PHASE_1_TO_2_ENG
+            elif (eng < t["phase_1_to_2_eng"]
                   and (state.missed_assignments_streak >= 1
-                       or state.social_integration < self._PHASE_1_SOCIAL_THRESHOLD)):
+                       or state.social_integration < t["phase_1_social"])):
                 state.dropout_phase = 2
                 state.memory.append({"week": week, "event_type": "dropout_phase",
                                     "details": "Thoughts of quitting: considering alternatives "
@@ -124,13 +167,13 @@ class BaulkeDropoutPhase:
 
         elif state.dropout_phase == 2:
             # Recovery back to 1
-            if eng > self._RECOVERY_2_TO_1:
+            if eng > t["recovery_2_to_1"]:
                 state.dropout_phase = 1
                 state.memory.append({"week": week, "event_type": "recovery",
                                     "details": "Renewed commitment, thoughts of quitting subsided",
                                     "impact": self._IMPACT_RECOVERY_2_TO_1})
             # Phase 2 -> 3: Deliberation (requires sustained decline or severe life shock)
-            elif (eng < self._PHASE_2_TO_3_ENG and len(history) >= 2 and history[-1] < history[-2]
+            elif (eng < t["phase_2_to_3_eng"] and len(history) >= 2 and history[-1] < history[-2]
                     or (state.env_shock_remaining > 0
                         and state.env_shock_magnitude > self._SHOCK_SEVERITY_THRESHOLD)):
                 state.dropout_phase = 3
@@ -140,13 +183,13 @@ class BaulkeDropoutPhase:
 
         elif state.dropout_phase == 3:
             # Recovery back to 2
-            if eng > self._RECOVERY_3_TO_2:
+            if eng > t["recovery_3_to_2"]:
                 state.dropout_phase = 2
                 state.memory.append({"week": week, "event_type": "recovery",
                                     "details": "Stepped back from deliberation to thoughts of quitting",
                                     "impact": self._IMPACT_RECOVERY_3_TO_2})
             # Phase 3 -> 4: Information search
-            elif eng < self._PHASE_3_TO_4_ENG and state.perceived_cost_benefit < self._PHASE_3_TO_4_CB:
+            elif eng < t["phase_3_to_4_eng"] and state.perceived_cost_benefit < self._PHASE_3_TO_4_CB:
                 state.dropout_phase = 4
                 state.memory.append({"week": week, "event_type": "dropout_phase",
                                     "details": "Information search: exploring alternatives "
@@ -155,12 +198,12 @@ class BaulkeDropoutPhase:
 
         elif state.dropout_phase == 4:
             # Recovery still possible but unlikely
-            if eng > self._RECOVERY_4_TO_3_ENG and state.perceived_cost_benefit > self._RECOVERY_4_TO_3_CB:
+            if eng > t["recovery_4_to_3_eng"] and state.perceived_cost_benefit > t["recovery_4_to_3_cb"]:
                 state.dropout_phase = 3
             # Phase 4 -> 5: Final decision -- probabilistic, scaled by triggers
             else:
                 triggers = 0
-                if eng < self._TRIGGER_ENG_THRESHOLD:
+                if eng < t["trigger_eng"]:
                     triggers += 1  # Near-zero engagement
                 if state.missed_assignments_streak >= self._TRIGGER_MISSED_STREAK:
                     triggers += 1  # Academic failure cascade

--- a/tests/test_baulke_institutional.py
+++ b/tests/test_baulke_institutional.py
@@ -1,0 +1,267 @@
+"""Tests for Baulke institutional modulation via InstitutionalConfig.
+
+Verifies that support_services_quality (SSQ) modulates dropout phase
+thresholds through scale_by(), with backward compatibility at SSQ=0.5.
+"""
+from __future__ import annotations
+
+import dataclasses
+
+import numpy as np
+import pytest
+
+from synthed.simulation.institutional import InstitutionalConfig, scale_by
+from synthed.simulation.theories.baulke import BaulkeDropoutPhase
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+def _make_state(
+    engagement: float = 0.50,
+    dropout_phase: int = 0,
+    social_integration: float = 0.30,
+    perceived_cost_benefit: float = 0.50,
+    missed_assignments_streak: int = 0,
+    perceived_mastery: float = 0.60,
+    perceived_mastery_count: int = 3,
+    exhaustion_level: float = 0.0,
+    weekly_engagement_history: list[float] | None = None,
+    env_shock_remaining: int = 0,
+    env_shock_magnitude: float = 0.0,
+):
+    """Minimal SimulationState-like object for unit tests."""
+
+    class _FakeExhaustion:
+        def __init__(self, level: float) -> None:
+            self.exhaustion_level = level
+
+    class _FakeCoI:
+        cognitive_presence: float = 0.50
+
+    class _FakeState:
+        pass
+
+    s = _FakeState()
+    s.current_engagement = engagement
+    s.dropout_phase = dropout_phase
+    s.social_integration = social_integration
+    s.perceived_cost_benefit = perceived_cost_benefit
+    s.missed_assignments_streak = missed_assignments_streak
+    s.perceived_mastery = perceived_mastery
+    s.perceived_mastery_count = perceived_mastery_count
+    s.exhaustion = _FakeExhaustion(exhaustion_level)
+    s.weekly_engagement_history = weekly_engagement_history or []
+    s.env_shock_remaining = env_shock_remaining
+    s.env_shock_magnitude = env_shock_magnitude
+    s.coi_state = _FakeCoI()
+    s.memory = []
+    return s
+
+
+def _make_persona(base_dropout_risk: float = 0.3, financial_stress: float = 0.3):
+    class _FakePersona:
+        pass
+
+    p = _FakePersona()
+    p.base_dropout_risk = base_dropout_risk
+    p.financial_stress = financial_stress
+    return p
+
+
+def _make_env(total_weeks: int = 14):
+    class _FakeEnv:
+        pass
+
+    e = _FakeEnv()
+    e.total_weeks = total_weeks
+    return e
+
+
+def _noop_td(student, state):
+    return 0.3
+
+
+# ── Test Class 1: Neutral Scaling ────────────────────────────────────────
+
+
+class TestNeutralScaling:
+    """SSQ=0.5 must reproduce class constants exactly."""
+
+    def test_scale_by_neutral(self):
+        """scale_by(c, 0.5) == c exactly (IEEE 754)."""
+        constants = [0.40, 0.45, 0.36, 0.32, 0.25, 0.10, 0.50, 0.45, 0.40, 0.35, 0.45, 0.20, 0.70]
+        for c in constants:
+            assert scale_by(c, 0.5) == c
+
+    def test_inst_none_matches_default(self):
+        """advance_phase(inst=None) == advance_phase(inst=default) for same state."""
+        baulke = BaulkeDropoutPhase()
+        default_inst = InstitutionalConfig()
+
+        # Forward paths (low engagement drives advancement)
+        for phase in range(5):
+            state_none = _make_state(engagement=0.30, dropout_phase=phase,
+                                     social_integration=0.10,
+                                     missed_assignments_streak=2,
+                                     weekly_engagement_history=[0.35, 0.32, 0.30])
+            state_inst = _make_state(engagement=0.30, dropout_phase=phase,
+                                     social_integration=0.10,
+                                     missed_assignments_streak=2,
+                                     weekly_engagement_history=[0.35, 0.32, 0.30])
+            persona = _make_persona()
+            env = _make_env()
+
+            rng_a = np.random.default_rng(99)
+            rng_b = np.random.default_rng(99)
+
+            baulke.advance_phase(persona, state_none, 5, env, _noop_td, rng_a, inst=None)
+            baulke.advance_phase(persona, state_inst, 5, env, _noop_td, rng_b, inst=default_inst)
+
+            assert state_none.dropout_phase == state_inst.dropout_phase, (
+                f"Forward phase {phase}: inst=None gave {state_none.dropout_phase}, "
+                f"inst=default gave {state_inst.dropout_phase}"
+            )
+
+        # Recovery paths (high engagement drives recovery)
+        for phase in [1, 2, 3, 4]:
+            state_none = _make_state(engagement=0.60, dropout_phase=phase,
+                                     perceived_cost_benefit=0.60,
+                                     weekly_engagement_history=[0.55, 0.58, 0.60])
+            state_inst = _make_state(engagement=0.60, dropout_phase=phase,
+                                     perceived_cost_benefit=0.60,
+                                     weekly_engagement_history=[0.55, 0.58, 0.60])
+            persona = _make_persona()
+            env = _make_env()
+
+            rng_a = np.random.default_rng(99)
+            rng_b = np.random.default_rng(99)
+
+            baulke.advance_phase(persona, state_none, 5, env, _noop_td, rng_a, inst=None)
+            baulke.advance_phase(persona, state_inst, 5, env, _noop_td, rng_b, inst=default_inst)
+
+            assert state_none.dropout_phase == state_inst.dropout_phase, (
+                f"Recovery phase {phase}: inst=None gave {state_none.dropout_phase}, "
+                f"inst=default gave {state_inst.dropout_phase}"
+            )
+
+
+# ── Test Class 2: Directional Scaling ────────────────────────────────────
+
+
+class TestDirectionalScaling:
+    """Verify threshold direction at SSQ=0.2 and SSQ=0.8."""
+
+    def test_forward_thresholds_high_ssq(self):
+        """SSQ=0.8 → forward thresholds LOWER than defaults."""
+        baulke = BaulkeDropoutPhase()
+        ssq = 0.8
+        forward_constants = [
+            baulke._NONFIT_ENG_THRESHOLD,
+            baulke._NONFIT_ENG_SOFT,
+            baulke._PHASE_1_TO_2_ENG,
+            baulke._PHASE_2_TO_3_ENG,
+            baulke._PHASE_3_TO_4_ENG,
+            baulke._TRIGGER_ENG_THRESHOLD,
+            baulke._PHASE_1_SOCIAL_THRESHOLD,
+        ]
+        for c in forward_constants:
+            scaled = scale_by(c, 1.0 - ssq)
+            assert scaled < c, f"scale_by({c}, {1.0 - ssq}) = {scaled} should be < {c}"
+
+    def test_forward_thresholds_low_ssq(self):
+        """SSQ=0.2 → forward thresholds HIGHER than defaults."""
+        baulke = BaulkeDropoutPhase()
+        ssq = 0.2
+        forward_constants = [
+            baulke._NONFIT_ENG_THRESHOLD,
+            baulke._NONFIT_ENG_SOFT,
+            baulke._PHASE_1_TO_2_ENG,
+            baulke._PHASE_2_TO_3_ENG,
+            baulke._PHASE_3_TO_4_ENG,
+            baulke._TRIGGER_ENG_THRESHOLD,
+            baulke._PHASE_1_SOCIAL_THRESHOLD,
+        ]
+        for c in forward_constants:
+            scaled = scale_by(c, 1.0 - ssq)
+            assert scaled > c, f"scale_by({c}, {1.0 - ssq}) = {scaled} should be > {c}"
+
+    def test_recovery_thresholds_high_ssq(self):
+        """SSQ=0.8 → recovery thresholds LOWER (easier to recover)."""
+        baulke = BaulkeDropoutPhase()
+        ssq = 0.8
+        recovery_constants = [
+            baulke._RECOVERY_1_TO_0,
+            baulke._RECOVERY_2_TO_1,
+            baulke._RECOVERY_3_TO_2,
+            baulke._RECOVERY_4_TO_3_ENG,
+            baulke._RECOVERY_4_TO_3_CB,
+        ]
+        for c in recovery_constants:
+            scaled = scale_by(c, 1.0 - ssq)
+            assert scaled < c, f"recovery scale_by({c}, {1.0 - ssq}) = {scaled} should be < {c}"
+
+    def test_exhaustion_threshold_high_ssq(self):
+        """SSQ=0.8 → exhaustion threshold HIGHER (harder to be exhausted)."""
+        baulke = BaulkeDropoutPhase()
+        scaled = scale_by(baulke._EXHAUSTION_THRESHOLD, 0.8)
+        assert scaled > baulke._EXHAUSTION_THRESHOLD
+
+    def test_exhaustion_threshold_low_ssq(self):
+        """SSQ=0.2 → exhaustion threshold LOWER (easier to be exhausted)."""
+        baulke = BaulkeDropoutPhase()
+        scaled = scale_by(baulke._EXHAUSTION_THRESHOLD, 0.2)
+        assert scaled < baulke._EXHAUSTION_THRESHOLD
+
+    def test_exact_values_at_boundaries(self):
+        """Verify exact scale_by outputs at SSQ=0.0 and SSQ=1.0."""
+        c = 0.40
+        assert scale_by(c, 0.0) == pytest.approx(c * 0.7)
+        assert scale_by(c, 1.0) == pytest.approx(c * 1.3)
+        assert scale_by(c, 0.5) == pytest.approx(c * 1.0)
+
+
+# ── Test Class 3: Integration Dropout Rate ───────────────────────────────
+
+
+class TestIntegrationDropoutRate:
+    """Integration test: SSQ affects actual dropout rates via full engine."""
+
+    @pytest.fixture()
+    def _run_simulation(self, tmp_path):
+        """Run pipeline with given SSQ value, return dropout rate."""
+        from synthed.pipeline import SynthEdPipeline
+
+        def _run(ssq: float, n: int = 200, seed: int = 42) -> float:
+            inst = dataclasses.replace(InstitutionalConfig(), support_services_quality=ssq)
+            pipeline = SynthEdPipeline(
+                institutional_config=inst,
+                output_dir=str(tmp_path),
+                seed=seed,
+            )
+            report = pipeline.run(n_students=n)
+            return report["simulation_summary"]["dropout_rate"]
+
+        return _run
+
+    def test_high_ssq_lower_dropout(self, _run_simulation):
+        """SSQ=0.8 should produce lower dropout than SSQ=0.5."""
+        default_rate = _run_simulation(0.5)
+        high_ssq_rate = _run_simulation(0.8)
+        assert high_ssq_rate < default_rate, (
+            f"SSQ=0.8 dropout {high_ssq_rate:.3f} should be < default {default_rate:.3f}"
+        )
+
+    def test_low_ssq_higher_dropout(self, _run_simulation):
+        """SSQ=0.2 should produce higher dropout than SSQ=0.5."""
+        default_rate = _run_simulation(0.5)
+        low_ssq_rate = _run_simulation(0.2)
+        assert low_ssq_rate > default_rate, (
+            f"SSQ=0.2 dropout {low_ssq_rate:.3f} should be > default {default_rate:.3f}"
+        )
+
+    def test_dropout_rate_sanity_bounds(self, _run_simulation):
+        """All SSQ values produce dropout in [0.01, 0.70]."""
+        for ssq in [0.1, 0.3, 0.5, 0.7, 0.9]:
+            rate = _run_simulation(ssq)
+            assert 0.01 <= rate <= 0.70, f"SSQ={ssq} dropout {rate:.3f} outside [0.01, 0.70]"


### PR DESCRIPTION
## Summary
- 13 Baulke phase-transition thresholds modulated by `support_services_quality` (SSQ) via `scale_by()`
- Forward thresholds inverted: high SSQ = harder to advance toward dropout
- Recovery thresholds inverted: high SSQ = easier to recover
- Exhaustion threshold direct: high SSQ = higher tolerance
- At SSQ=0.5 all thresholds equal class constants exactly (backward compatible)
- Threshold computation extracted to `_modulated_thresholds()` helper

## Test plan
- [x] 666 tests pass (11 new for Baulke institutional modulation)
- [x] Neutral scaling: SSQ=0.5 reproduces class constants within 1e-10
- [x] Directional: SSQ=0.8 lowers forward + recovery thresholds, raises exhaustion
- [x] Backward compat: inst=None == inst=default for forward AND recovery paths
- [x] Integration: SSQ=0.2 → higher dropout, SSQ=0.8 → lower dropout
- [x] Sanity: all dropout rates in [0.01, 0.70] for SSQ range
- [x] ruff clean, doc_facts consistent
- [x] Code review: HIGH (function length) + 2 MEDIUM fixed
- [x] Security review: no issues found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `support_services_quality` configuration parameter to modulate institutional dropout thresholds; higher values reduce dropout rates while lower values increase them.

* **Documentation**
  * Updated institutional configuration guide and theoretical documentation to explain the new parameter and its effects on dropout phase modeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->