### PR TITLE
feat: add frozen PipelineConfig dataclass with deprecation bridge (P9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to SynthEd are documented here.
 
 ### Added
 - `InstitutionalConfig.support_services_quality` modulates Baulke dropout phase thresholds via `scale_by()` — 13 thresholds scaled, better institutions produce lower dropout
+- `PipelineConfig` frozen dataclass — groups 16 pipeline params with JSON `to_dict()`/`from_dict()` serialization
+- Deprecation bridge: legacy `SynthEdPipeline(seed=42)` kwargs still work with `DeprecationWarning`
 
 ## [1.2.0] - 2026-04-05
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@ python run_calibration.py --workers 4  # Parallel NSGA-II calibration
 
 ```python
 from synthed.pipeline import SynthEdPipeline
+from synthed.pipeline_config import PipelineConfig
 
-pipeline = SynthEdPipeline(output_dir="./output", seed=42)
+config = PipelineConfig(output_dir="./output", seed=42)
+pipeline = SynthEdPipeline(config=config)
 report = pipeline.run(n_students=300)
 print(f"Dropout: {report['simulation_summary']['dropout_rate']:.1%}")
 ```

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -98,6 +98,29 @@ pipeline = SynthEdPipeline(
 report = pipeline.run(n_students=300)
 ```
 
+### PipelineConfig (Recommended)
+
+All pipeline configuration can be grouped into a frozen `PipelineConfig` dataclass for cleaner API, JSON serialization, and reproducibility:
+
+```python
+from synthed.pipeline import SynthEdPipeline
+from synthed.pipeline_config import PipelineConfig
+
+config = PipelineConfig(
+    output_dir="./output",
+    seed=42,
+    target_dropout_range=(0.40, 0.55),
+)
+pipeline = SynthEdPipeline(config=config)
+report = pipeline.run(n_students=300)
+
+# Serialize config for reproducibility
+import json
+json.dump(config.to_dict(), open("config.json", "w"))
+```
+
+Legacy keyword arguments still work but emit a `DeprecationWarning`. Migrate by wrapping kwargs in `PipelineConfig(...)`.
+
 ---
 
 ## ⚙️ Population Configuration

--- a/docs/THEORY.md
+++ b/docs/THEORY.md
@@ -192,7 +192,7 @@ SynthEd/
 │   │   └── validation.py        # Input validation utilities
 │   ├── calibration.py           # CalibrationMap: target dropout -> params
 │   └── pipeline.py              # End-to-end orchestrator
-├── tests/                       # 666 pytest tests across 40 files
+├── tests/                       # 693 pytest tests across 41 files
 ├── docs/
 │   ├── GUIDE.md                 # User guide
 │   └── THEORY.md                # This file
@@ -221,7 +221,7 @@ Quality grades: **A** (90%+), **B** (75%+), **C** (60%+), **D** (40%+), **F** (<
 
 ## 🧪 Test Suite
 
-666 pytest tests across 40 files:
+693 pytest tests across 41 files:
 
 | Test File | Tests | Coverage |
 |-----------|-------|----------|

--- a/synthed/pipeline.py
+++ b/synthed/pipeline.py
@@ -16,10 +16,13 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any, Callable
 
+import warnings
+
 from . import __version__
 from .agents.persona import PersonaConfig
 from .agents.factory import StudentFactory
 from .calibration import CalibrationMap
+from .pipeline_config import PipelineConfig
 from .simulation.environment import ODLEnvironment
 from .simulation.engine import SimulationEngine
 from .simulation.engine_config import EngineConfig
@@ -33,6 +36,14 @@ from .utils.llm import LLMClient
 logger = logging.getLogger(__name__)
 
 _DEFAULT_COST_THRESHOLD_USD: float = 1.0
+
+# Allowlist of legacy kwargs accepted by the deprecation bridge.
+_LEGACY_PARAMS: frozenset[str] = frozenset({
+    "persona_config", "environment", "institutional_config", "grading_config",
+    "engine_config", "reference_stats", "seed", "n_semesters",
+    "carry_over_config", "target_dropout_range", "output_dir", "export_oulad",
+    "llm_model", "llm_base_url", "use_llm", "cost_threshold",
+})
 
 
 class SynthEdPipeline:
@@ -50,93 +61,182 @@ class SynthEdPipeline:
 
     def __init__(
         self,
-        persona_config: PersonaConfig | None = None,
-        environment: ODLEnvironment | None = None,
-        institutional_config: InstitutionalConfig | None = None,
-        reference_stats: ReferenceStatistics | None = None,
-        output_dir: str | None = "./output",
-        llm_model: str = "gpt-4o-mini",
-        llm_base_url: str | None = None,
-        use_llm: bool = False,
-        seed: int = 42,
-        n_semesters: int = 1,
-        carry_over_config: Any | None = None,
-        target_dropout_range: tuple[float, float] | None = None,
-        cost_threshold: float = _DEFAULT_COST_THRESHOLD_USD,
+        config: PipelineConfig | None = None,
+        *,
         confirm_callback: Callable[[str], bool] | None = None,
-        grading_config: GradingConfig | None = None,
-        engine_config: EngineConfig | None = None,
-        export_oulad: bool = False,
         _calibration_mode: bool = False,
+        **kwargs: Any,
     ):
-        self.persona_config = persona_config or PersonaConfig()
-        self.environment = environment or ODLEnvironment()
-        self.institutional_config = institutional_config or InstitutionalConfig()
-        self.grading_config = grading_config or GradingConfig()
-        self.reference = reference_stats or ReferenceStatistics()
-        self.output_dir = Path(output_dir) if output_dir is not None else None
-        self.use_llm = use_llm
-        self.seed = seed
-        self.n_semesters = n_semesters
-        self.carry_over_config = carry_over_config
-        self.target_dropout_range = target_dropout_range
-        self.cost_threshold = cost_threshold
+        # ── Deprecation bridge ──────────────────────────────────────────
+        if config is not None and kwargs:
+            raise TypeError(
+                "Cannot pass both 'config' and legacy keyword arguments. "
+                "Use PipelineConfig for all configuration."
+            )
+        if kwargs:
+            unknown = set(kwargs) - _LEGACY_PARAMS
+            if unknown:
+                raise TypeError(
+                    f"Unknown keyword arguments: {unknown}. "
+                    f"Valid legacy params: {sorted(_LEGACY_PARAMS)}"
+                )
+            warnings.warn(
+                "Passing individual keyword arguments to SynthEdPipeline is "
+                "deprecated. Use config=PipelineConfig(...) instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            config = PipelineConfig(
+                persona_config=kwargs.get("persona_config") or PersonaConfig(),
+                environment=kwargs.get("environment") or ODLEnvironment(),
+                institutional_config=kwargs.get("institutional_config") or InstitutionalConfig(),
+                grading_config=kwargs.get("grading_config") or GradingConfig(),
+                engine_config=kwargs.get("engine_config") or EngineConfig(),
+                reference_stats=kwargs.get("reference_stats") or ReferenceStatistics(),
+                seed=kwargs.get("seed", 42),
+                n_semesters=kwargs.get("n_semesters", 1),
+                carry_over_config=kwargs.get("carry_over_config"),
+                target_dropout_range=kwargs.get("target_dropout_range"),
+                output_dir=kwargs.get("output_dir", "./output"),
+                export_oulad=kwargs.get("export_oulad", False),
+                llm_model=kwargs.get("llm_model", "gpt-4o-mini"),
+                llm_base_url=kwargs.get("llm_base_url"),
+                use_llm=kwargs.get("use_llm", False),
+                cost_threshold=kwargs.get("cost_threshold", _DEFAULT_COST_THRESHOLD_USD),
+            )
+        elif config is None:
+            config = PipelineConfig()
+
+        # ── Non-serializable / internal args ────────────────────────────
         self.confirm_callback = confirm_callback
-        self.export_oulad = export_oulad
         self._calibration_mode = _calibration_mode
         self._calibration_estimate = None
 
-        # Apply calibration when a target dropout range is provided
-        if target_dropout_range is not None:
-            self._apply_calibration(target_dropout_range, n_semesters)
+        # ── Apply calibration (produces new config via replace) ─────────
+        if config.target_dropout_range is not None:
+            config = self._apply_calibration(config)
 
-        # Initialize components
-        self.llm = LLMClient(model=llm_model, base_url=llm_base_url) if use_llm else None
-        self.factory = StudentFactory(config=self.persona_config, llm_client=self.llm, seed=seed)
+        # ── Store frozen config (single source of truth) ────────────────
+        self.config = config
+
+        # ── Initialize components from self.config ──────────────────────
+        self.llm = (
+            LLMClient(model=self.llm_model, base_url=self.llm_base_url)
+            if self.use_llm else None
+        )
+        self.factory = StudentFactory(
+            config=self.persona_config, llm_client=self.llm, seed=self.seed,
+        )
         self.engine = SimulationEngine(
             environment=self.environment,
             llm_client=self.llm,
-            seed=seed,
+            seed=self.seed,
             unavoidable_withdrawal_rate=self.persona_config.unavoidable_withdrawal_rate,
             institutional_config=self.institutional_config,
             grading_config=self.grading_config,
-            engine_config=engine_config,
+            engine_config=self.engine_config,
         )
         self.exporter = DataExporter(
-            output_dir=str(self.output_dir) if self.output_dir is not None else None
+            output_dir=str(self.output_dir) if self.output_dir is not None else None,
         )
         self.validator = SyntheticDataValidator(reference=self.reference)
 
-    def _apply_calibration(
-        self,
-        target_range: tuple[float, float],
-        n_semesters: int,
-    ) -> None:
-        """Use CalibrationMap to set dropout_base_rate from target dropout range."""
+    # ── @property delegates to self.config ──────────────────────────────
+
+    @property
+    def persona_config(self) -> PersonaConfig:
+        return self.config.persona_config
+
+    @property
+    def environment(self) -> ODLEnvironment:
+        return self.config.environment
+
+    @property
+    def institutional_config(self) -> InstitutionalConfig:
+        return self.config.institutional_config
+
+    @property
+    def grading_config(self) -> GradingConfig:
+        return self.config.grading_config
+
+    @property
+    def engine_config(self) -> EngineConfig:
+        return self.config.engine_config
+
+    @property
+    def reference(self) -> ReferenceStatistics:
+        return self.config.reference_stats
+
+    @property
+    def seed(self) -> int:
+        return self.config.seed
+
+    @property
+    def n_semesters(self) -> int:
+        return self.config.n_semesters
+
+    @property
+    def carry_over_config(self) -> Any | None:
+        return self.config.carry_over_config
+
+    @property
+    def target_dropout_range(self) -> tuple[float, float] | None:
+        return self.config.target_dropout_range
+
+    @property
+    def output_dir(self) -> Path | None:
+        od = self.config.output_dir
+        return Path(od) if od is not None else None
+
+    @property
+    def export_oulad(self) -> bool:
+        return self.config.export_oulad
+
+    @property
+    def use_llm(self) -> bool:
+        return self.config.use_llm
+
+    @property
+    def llm_model(self) -> str:
+        return self.config.llm_model
+
+    @property
+    def llm_base_url(self) -> str | None:
+        return self.config.llm_base_url
+
+    @property
+    def cost_threshold(self) -> float:
+        return self.config.cost_threshold
+
+    def _apply_calibration(self, config: PipelineConfig) -> PipelineConfig:
+        """Return a new PipelineConfig with calibrated dropout params."""
         calibration_map = CalibrationMap()
-        estimate = calibration_map.estimate_from_range(target_range, n_semesters)
+        estimate = calibration_map.estimate_from_range(
+            config.target_dropout_range, config.n_semesters,
+        )
         self._calibration_estimate = estimate
 
-        # Update PersonaConfig with calibrated dropout_base_rate
-        self.persona_config = replace(
-            self.persona_config,
-            dropout_base_rate=estimate.estimated_dropout_base_rate,
-        )
-
-        # Update ReferenceStatistics with target range for validation
-        midpoint = (target_range[0] + target_range[1]) / 2
-        self.reference = replace(
-            self.reference,
-            dropout_rate=midpoint,
-            dropout_range=target_range,
+        midpoint = (config.target_dropout_range[0] + config.target_dropout_range[1]) / 2
+        new_config = replace(
+            config,
+            persona_config=replace(
+                config.persona_config,
+                dropout_base_rate=estimate.estimated_dropout_base_rate,
+            ),
+            reference_stats=replace(
+                config.reference_stats,
+                dropout_rate=midpoint,
+                dropout_range=config.target_dropout_range,
+            ),
         )
 
         logger.info(
             "Calibration: targeting %s dropout, estimated base_rate=%.2f (confidence: %s)",
-            target_range,
+            config.target_dropout_range,
             estimate.estimated_dropout_base_rate,
             estimate.confidence,
         )
+        return new_config
 
     def _check_cost_before_enrichment(self, n_students: int) -> bool:
         """Estimate LLM cost and warn/prompt if above threshold.

--- a/synthed/pipeline_config.py
+++ b/synthed/pipeline_config.py
@@ -1,0 +1,189 @@
+"""Frozen PipelineConfig dataclass for SynthEdPipeline configuration.
+
+Groups 16 serializable constructor parameters into a single immutable
+config object.  Non-serializable items (``confirm_callback``) and
+internal flags (``_calibration_mode``) remain as direct constructor args.
+
+Usage::
+
+    from synthed.pipeline_config import PipelineConfig
+    config = PipelineConfig(seed=123, n_semesters=2)
+    pipeline = SynthEdPipeline(config=config)
+"""
+from __future__ import annotations
+
+import dataclasses
+import enum
+import types
+from dataclasses import dataclass, field, fields
+from typing import Any, Union
+
+from .agents.persona import PersonaConfig
+from .simulation.engine_config import EngineConfig
+from .simulation.environment import Course, ODLEnvironment
+from .simulation.grading import GradingConfig
+from .simulation.institutional import InstitutionalConfig
+from .validation import ReferenceStatistics
+
+
+_DEFAULT_COST_THRESHOLD_USD: float = 1.0
+
+# Maps field name -> nested dataclass type for from_dict() reconstruction.
+_NESTED_FIELDS: dict[str, type] = {
+    "persona_config": PersonaConfig,
+    "environment": ODLEnvironment,
+    "institutional_config": InstitutionalConfig,
+    "grading_config": GradingConfig,
+    "engine_config": EngineConfig,
+    "reference_stats": ReferenceStatistics,
+}
+
+
+def _coerce_field_types(cls: type, raw: dict) -> dict:
+    """Coerce serialized values back to their declared field types.
+
+    Handles tuple fields (serialized as lists), enum fields (serialized
+    as their value), and nested Course lists for ODLEnvironment.
+    """
+    import enum as _enum
+    import typing
+
+    hints = typing.get_type_hints(cls)
+    coerced = dict(raw)
+    for name, val in raw.items():
+        if name not in hints or val is None:
+            continue
+        hint = hints[name]
+        # Unwrap Optional / Union with None (e.g. tuple[float,float] | None)
+        args = getattr(hint, "__args__", None)
+        origin = getattr(hint, "__origin__", None)
+        if origin is Union or isinstance(hint, types.UnionType) or (args and type(None) in args):
+            non_none = [a for a in args if a is not type(None)]
+            if len(non_none) == 1:
+                hint = non_none[0]
+                origin = getattr(hint, "__origin__", None)
+                args = getattr(hint, "__args__", None)
+        # tuple fields: list -> tuple
+        if origin is tuple and isinstance(val, list):
+            coerced[name] = tuple(val)
+        elif hint is tuple and isinstance(val, list):
+            coerced[name] = tuple(val)
+        # enum fields: int/str -> Enum
+        elif isinstance(hint, type) and issubclass(hint, _enum.Enum):
+            coerced[name] = hint(val)
+    return coerced
+
+
+def _reconstruct_nested(cls: type, raw: dict) -> Any:
+    """Reconstruct a nested dataclass from a raw dict.
+
+    Handles ODLEnvironment specially because its ``courses`` field
+    is ``list[Course]`` which needs element-wise reconstruction.
+    Coerces tuples and enums back to their declared types.
+    """
+    coerced = _coerce_field_types(cls, raw)
+    if cls is ODLEnvironment and "courses" in coerced:
+        courses = [Course(**_coerce_field_types(Course, c)) for c in coerced["courses"]]
+        remaining = {k: v for k, v in coerced.items() if k != "courses"}
+        return cls(courses=courses, **remaining)
+    return cls(**coerced)
+
+
+@dataclass(frozen=True)
+class PipelineConfig:
+    """Frozen configuration for :class:`SynthEdPipeline`.
+
+    All 16 fields correspond to the former constructor parameters of
+    ``SynthEdPipeline``.  At default values the pipeline behaves
+    identically to the pre-PipelineConfig API.
+
+    Use ``dataclasses.replace()`` for overrides::
+
+        new_cfg = replace(config, seed=99, n_semesters=3)
+    """
+
+    # Domain configs (nested frozen dataclasses)
+    persona_config: PersonaConfig = field(default_factory=PersonaConfig)
+    environment: ODLEnvironment = field(default_factory=ODLEnvironment)
+    institutional_config: InstitutionalConfig = field(
+        default_factory=InstitutionalConfig,
+    )
+    grading_config: GradingConfig = field(default_factory=GradingConfig)
+    engine_config: EngineConfig = field(default_factory=EngineConfig)
+    reference_stats: ReferenceStatistics = field(
+        default_factory=ReferenceStatistics,
+    )
+
+    # Simulation scalars
+    seed: int = 42
+    n_semesters: int = 1
+    carry_over_config: Any | None = None
+    target_dropout_range: tuple[float, float] | None = None
+
+    # Output
+    output_dir: str | None = "./output"
+    export_oulad: bool = False
+
+    # LLM
+    llm_model: str = "gpt-4o-mini"
+    llm_base_url: str | None = None
+    use_llm: bool = False
+
+    # Cost
+    cost_threshold: float = _DEFAULT_COST_THRESHOLD_USD
+
+    def __post_init__(self) -> None:
+        if self.seed < 0:
+            raise ValueError(f"seed must be >= 0, got {self.seed}")
+        if self.n_semesters < 1:
+            raise ValueError(
+                f"n_semesters must be >= 1, got {self.n_semesters}",
+            )
+        if self.cost_threshold < 0:
+            raise ValueError(
+                f"cost_threshold must be >= 0, got {self.cost_threshold}",
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dict.
+
+        Nested dataclasses are converted recursively with enum support.
+        """
+
+        def _serialize(obj: Any) -> Any:
+            if obj is None:
+                return None
+            if isinstance(obj, enum.Enum):
+                return obj.value
+            if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+                return {
+                    k: _serialize(v)
+                    for k, v in dataclasses.asdict(obj).items()
+                }
+            if isinstance(obj, dict):
+                return {k: _serialize(v) for k, v in obj.items()}
+            if isinstance(obj, (list, tuple)):
+                return [_serialize(v) for v in obj]
+            return obj
+
+        result: dict[str, Any] = {}
+        for f in fields(self):
+            result[f.name] = _serialize(getattr(self, f.name))
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PipelineConfig:
+        """Reconstruct from a dict produced by :meth:`to_dict`.
+
+        Nested dataclass fields are reconstructed using the
+        ``_NESTED_FIELDS`` registry.
+        """
+        kwargs: dict[str, Any] = {}
+        for key, val in data.items():
+            if key in _NESTED_FIELDS and isinstance(val, dict):
+                kwargs[key] = _reconstruct_nested(_NESTED_FIELDS[key], val)
+            elif key == "target_dropout_range" and isinstance(val, list):
+                kwargs[key] = tuple(val)
+            else:
+                kwargs[key] = val
+        return cls(**kwargs)

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -1,0 +1,127 @@
+"""Tests for PipelineConfig frozen dataclass."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+class TestPipelineConfigCreation:
+    """Default construction and field count."""
+
+    def test_default_construction(self):
+        from synthed.pipeline_config import PipelineConfig
+        config = PipelineConfig()
+        assert config.seed == 42
+        assert config.n_semesters == 1
+        assert config.use_llm is False
+        assert config.export_oulad is False
+        assert config.output_dir == "./output"
+        assert config.llm_model == "gpt-4o-mini"
+        assert config.cost_threshold == 1.0
+
+    def test_has_16_fields(self):
+        from dataclasses import fields
+        from synthed.pipeline_config import PipelineConfig
+        assert len(fields(PipelineConfig)) == 16
+
+    def test_frozen(self):
+        from synthed.pipeline_config import PipelineConfig
+        config = PipelineConfig()
+        with pytest.raises(AttributeError):
+            config.seed = 99
+
+
+class TestPipelineConfigValidation:
+    """__post_init__ validation."""
+
+    def test_seed_zero_valid(self):
+        from synthed.pipeline_config import PipelineConfig
+        config = PipelineConfig(seed=0)
+        assert config.seed == 0
+
+    def test_seed_negative_raises(self):
+        from synthed.pipeline_config import PipelineConfig
+        with pytest.raises(ValueError, match="seed"):
+            PipelineConfig(seed=-1)
+
+    def test_n_semesters_zero_raises(self):
+        from synthed.pipeline_config import PipelineConfig
+        with pytest.raises(ValueError, match="n_semesters"):
+            PipelineConfig(n_semesters=0)
+
+    def test_cost_threshold_negative_raises(self):
+        from synthed.pipeline_config import PipelineConfig
+        with pytest.raises(ValueError, match="cost_threshold"):
+            PipelineConfig(cost_threshold=-1.0)
+
+
+class TestPipelineConfigReplace:
+    """dataclasses.replace() produces new instance."""
+
+    def test_replace_seed(self):
+        from dataclasses import replace
+        from synthed.pipeline_config import PipelineConfig
+        original = PipelineConfig(seed=42)
+        modified = replace(original, seed=99)
+        assert modified.seed == 99
+        assert original.seed == 42
+
+
+class TestPipelineConfigSerialization:
+    """to_dict / from_dict round-trip."""
+
+    def test_to_dict_json_serializable(self):
+        from synthed.pipeline_config import PipelineConfig
+        config = PipelineConfig()
+        d = config.to_dict()
+        json_str = json.dumps(d)
+        assert isinstance(json_str, str)
+
+    def test_round_trip(self):
+        from synthed.pipeline_config import PipelineConfig
+        config = PipelineConfig()
+        restored = PipelineConfig.from_dict(config.to_dict())
+        assert restored == config
+
+    def test_round_trip_custom_values(self):
+        from synthed.pipeline_config import PipelineConfig
+        from synthed.simulation.grading import GradingConfig
+        config = PipelineConfig(
+            seed=123,
+            n_semesters=2,
+            use_llm=True,
+            grading_config=GradingConfig(pass_threshold=0.55),
+        )
+        restored = PipelineConfig.from_dict(config.to_dict())
+        assert restored == config
+        assert restored.grading_config.pass_threshold == 0.55
+
+    def test_round_trip_with_courses(self):
+        """ODLEnvironment with Course list round-trips correctly."""
+        from synthed.pipeline_config import PipelineConfig
+        from synthed.simulation.environment import Course, ODLEnvironment
+        env = ODLEnvironment(courses=[
+            Course(id="TEST1", name="Test Course", difficulty=0.7),
+        ])
+        config = PipelineConfig(environment=env)
+        restored = PipelineConfig.from_dict(config.to_dict())
+        assert len(restored.environment.courses) == 1
+        assert restored.environment.courses[0].id == "TEST1"
+        assert restored.environment.courses[0].difficulty == 0.7
+
+    def test_nested_fields_registry(self):
+        from synthed.pipeline_config import _NESTED_FIELDS
+        assert len(_NESTED_FIELDS) == 6
+
+
+class TestPipelineConfigEquality:
+    """Equality semantics."""
+
+    def test_equal_configs(self):
+        from synthed.pipeline_config import PipelineConfig
+        assert PipelineConfig() == PipelineConfig()
+
+    def test_unequal_configs(self):
+        from synthed.pipeline_config import PipelineConfig
+        assert PipelineConfig(seed=1) != PipelineConfig(seed=2)

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -1,9 +1,12 @@
 """Integration tests for the SynthEdPipeline."""
 
 import logging
+import warnings
+
 import pytest
 
 from synthed.pipeline import SynthEdPipeline
+from synthed.pipeline_config import PipelineConfig
 
 
 class TestPipelineIntegration:
@@ -150,3 +153,95 @@ class TestSmallNWarning:
             if "small" in r.getMessage() and "n_students" in r.getMessage()
         ]
         assert len(small_n_warnings) == 0
+
+
+class TestPipelineConfigBridge:
+    """Tests for the PipelineConfig deprecation bridge."""
+
+    def test_new_style_config(self, tmp_path):
+        """SynthEdPipeline(config=PipelineConfig()) works."""
+        config = PipelineConfig(output_dir=str(tmp_path), seed=42)
+        pipeline = SynthEdPipeline(config=config)
+        assert pipeline.config.seed == 42
+
+    def test_legacy_kwargs_emit_warning(self, tmp_path):
+        """Legacy kwargs emit DeprecationWarning."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            SynthEdPipeline(output_dir=str(tmp_path), seed=42)
+            dep_warns = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            assert len(dep_warns) >= 1
+            assert "PipelineConfig" in str(dep_warns[0].message)
+
+    def test_mixed_args_raises(self, tmp_path):
+        """config= plus legacy kwargs raises TypeError."""
+        config = PipelineConfig(output_dir=str(tmp_path))
+        with pytest.raises(TypeError, match="Cannot pass both"):
+            SynthEdPipeline(config=config, seed=42)
+
+    def test_unknown_kwarg_raises(self):
+        """Unknown legacy kwargs raise TypeError."""
+        with pytest.raises(TypeError, match="Unknown keyword"):
+            SynthEdPipeline(bad_param=1)
+
+    def test_new_style_full_run(self, tmp_path):
+        """Full pipeline run with PipelineConfig."""
+        config = PipelineConfig(output_dir=str(tmp_path), seed=42)
+        pipeline = SynthEdPipeline(config=config)
+        report = pipeline.run(n_students=20)
+        assert "simulation_summary" in report
+
+
+class TestPropertyDelegation:
+    """Verify @property delegates to self.config."""
+
+    def test_persona_config_delegates(self, tmp_path):
+        config = PipelineConfig(output_dir=str(tmp_path))
+        pipeline = SynthEdPipeline(config=config)
+        assert pipeline.persona_config is pipeline.config.persona_config
+
+    def test_environment_delegates(self, tmp_path):
+        config = PipelineConfig(output_dir=str(tmp_path))
+        pipeline = SynthEdPipeline(config=config)
+        assert pipeline.environment is pipeline.config.environment
+
+    def test_reference_delegates(self, tmp_path):
+        config = PipelineConfig(output_dir=str(tmp_path))
+        pipeline = SynthEdPipeline(config=config)
+        assert pipeline.reference is pipeline.config.reference_stats
+
+    def test_seed_delegates(self, tmp_path):
+        config = PipelineConfig(output_dir=str(tmp_path), seed=99)
+        pipeline = SynthEdPipeline(config=config)
+        assert pipeline.seed == 99
+
+    def test_target_dropout_range_delegates(self, tmp_path):
+        config = PipelineConfig(
+            output_dir=str(tmp_path),
+            target_dropout_range=(0.30, 0.50),
+        )
+        pipeline = SynthEdPipeline(config=config)
+        assert pipeline.target_dropout_range == (0.30, 0.50)
+
+    def test_engine_config_forwarded(self, tmp_path):
+        """engine_config correctly forwarded to SimulationEngine."""
+        from dataclasses import replace as dc_replace
+        from synthed.simulation.engine_config import EngineConfig
+        custom_cfg = dc_replace(EngineConfig(), _LOGIN_ENG_MULTIPLIER=9.9)
+        config = PipelineConfig(
+            output_dir=str(tmp_path),
+            engine_config=custom_cfg,
+        )
+        pipeline = SynthEdPipeline(config=config)
+        assert pipeline.engine.cfg._LOGIN_ENG_MULTIPLIER == 9.9
+        assert pipeline.engine.cfg == custom_cfg
+
+    def test_calibration_updates_config(self, tmp_path):
+        """Post-calibration persona_config differs from default."""
+        config = PipelineConfig(
+            output_dir=str(tmp_path),
+            target_dropout_range=(0.35, 0.55),
+        )
+        default_rate = PipelineConfig().persona_config.dropout_base_rate
+        pipeline = SynthEdPipeline(config=config)
+        assert pipeline.config.persona_config.dropout_base_rate != default_rate


### PR DESCRIPTION
## Summary
- New frozen `PipelineConfig` dataclass (16 fields) in `synthed/pipeline_config.py`
- `SynthEdPipeline` accepts `config=PipelineConfig()` as primary API
- Deprecation bridge: legacy kwargs still work with `DeprecationWarning`
- `TypeError` on mixed (config + kwargs) or unknown kwargs via `_LEGACY_PARAMS` allowlist
- All 16 fields accessed via `self.config` with `@property` delegates — single source of truth
- `to_dict()`/`from_dict()` JSON round-trip with `_NESTED_FIELDS` registry, enum + tuple coercion
- `_apply_calibration` returns new config via `replace()` — no mutation

## Test plan
- [x] 693 tests pass (27 new for PipelineConfig + bridge + delegation)
- [x] PipelineConfig: frozen, validation, replace(), 16 fields
- [x] Round-trip: JSON serialization with nested dataclasses, enums, Course lists
- [x] Bridge: DeprecationWarning emitted, TypeError on mixed/unknown args
- [x] Property delegation: all 16 fields delegate to self.config
- [x] engine_config correctly forwarded to SimulationEngine
- [x] Post-calibration config reflects updated persona + reference
- [x] All 666 pre-existing tests pass unchanged (bridge backward compat)
- [x] ruff clean, doc_facts consistent