### PR TITLE
fix: address CodeRabbit P9 nitpicks

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -116,7 +116,8 @@ report = pipeline.run(n_students=300)
 
 # Serialize config for reproducibility
 import json
-json.dump(config.to_dict(), open("config.json", "w"))
+with open("config.json", "w") as f:
+    json.dump(config.to_dict(), f)
 ```
 
 Legacy keyword arguments still work but emit a `DeprecationWarning`. Migrate by wrapping kwargs in `PipelineConfig(...)`.

--- a/synthed/pipeline.py
+++ b/synthed/pipeline.py
@@ -297,12 +297,12 @@ class SynthEdPipeline:
             )
 
         profile = PROFILES[profile_name]
-        return cls(
+        config = PipelineConfig(
             persona_config=profile.persona_config,
             environment=profile.environment,
             institutional_config=profile.institutional_config,
             grading_config=profile.grading_config,
-            engine_config=engine_config,
+            engine_config=engine_config or EngineConfig(),
             reference_stats=profile.reference_stats,
             output_dir=output_dir,
             use_llm=use_llm,
@@ -311,8 +311,8 @@ class SynthEdPipeline:
             seed=profile.seed,
             target_dropout_range=profile.expected_dropout_range,
             cost_threshold=cost_threshold,
-            confirm_callback=confirm_callback,
         )
+        return cls(config=config, confirm_callback=confirm_callback)
 
     def run(
         self,

--- a/synthed/pipeline_config.py
+++ b/synthed/pipeline_config.py
@@ -143,6 +143,12 @@ class PipelineConfig:
             raise ValueError(
                 f"cost_threshold must be >= 0, got {self.cost_threshold}",
             )
+        if self.target_dropout_range is not None:
+            lo, hi = self.target_dropout_range
+            if lo > hi:
+                raise ValueError(
+                    f"target_dropout_range must have lo <= hi, got {self.target_dropout_range}",
+                )
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dict.

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -21,8 +21,10 @@ class TestPipelineConfigCreation:
         assert config.cost_threshold == 1.0
 
     def test_has_16_fields(self):
+        """Contract test: PipelineConfig field count is part of the public API."""
         from dataclasses import fields
         from synthed.pipeline_config import PipelineConfig
+        # Deliberate: adding/removing fields is a breaking change and must be reviewed
         assert len(fields(PipelineConfig)) == 16
 
     def test_frozen(self):


### PR DESCRIPTION
## Summary
- `from_profile()` now constructs `PipelineConfig` directly — no self-deprecation warning
- `target_dropout_range` ordering validation in `__post_init__` (rejects inverted ranges)
- GUIDE.md: `open()` → `with` context manager in serialization example
- Contract test comment on field count assertion

## Test plan
- [x] 693 tests pass
- [x] ruff clean
- [x] Deprecation warnings reduced (131 → from_profile no longer triggers)