### PR TITLE
docs: correct theory count 11→10, merge Unavoidable Withdrawal into Bean & Metzner

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ python run_pipeline.py --n 200      # or: pip install synthedu
 
 ## Key Features
 
-- **11 Theory Modules** -- Tinto, Bean & Metzner, Kember, SDT, Garrison CoI, Moore, Rovai, Baulke, Epstein & Axtell, Gonzalez, Unavoidable Withdrawal
+- **10 Theory Modules** -- Tinto, Bean & Metzner, Kember, SDT, Garrison CoI, Moore, Rovai, Baulke, Epstein & Axtell, Gonzalez (+ unavoidable withdrawal mechanism)
 - **Trait-Based Calibration** -- Sobol sensitivity (69 params) + NSGA-II multi-objective optimization against real OULAD data
 - **Multi-Semester Simulation** -- Carry-over mechanics for engagement, GPA, coping, dropout phases
 - **GPA Feedback Loop** -- Cumulative GPA anchors cost-benefit, non-fit perception, and competence beliefs
@@ -90,14 +90,14 @@ print(f"Dropout: {report['simulation_summary']['dropout_rate']:.1%}")
 | Document | Content |
 |----------|---------|
 | **[User Guide](docs/GUIDE.md)** | Installation, configuration, calibration pipeline, OULAD export, LLM enrichment, troubleshooting |
-| **[Theory & Architecture](docs/THEORY.md)** | 11 theoretical anchors, factor clusters, architecture diagram, project structure, validation suite, test inventory |
+| **[Theory & Architecture](docs/THEORY.md)** | 10 theoretical anchors, factor clusters, architecture diagram, project structure, validation suite, test inventory |
 
 ---
 
 ## Roadmap
 
 - [x] Multi-semester simulation with carry-over
-- [x] 11 theory modules (Tinto, Bean & Metzner, Kember, SDT, Garrison, Moore, Rovai, Baulke, Epstein & Axtell, Gonzalez, Unavoidable Withdrawal)
+- [x] 10 theory modules (Tinto, Bean & Metzner, Kember, SDT, Garrison, Moore, Rovai, Baulke, Epstein & Axtell, Gonzalez)
 - [x] Trait-based calibration (Sobol + Optuna + OULAD validation)
 - [x] Benchmark reports with CLI (`--benchmark`)
 - [x] OULAD-compatible 7-table export

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19334118.svg)](https://doi.org/10.5281/zenodo.19334118)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**Agent-based simulation environment for Open & Distance Learning (ODL) research.** SynthEd generates behaviorally grounded and temporally coherent learning trajectories by combining persona-driven agent modeling with 11 established theoretical frameworks. Built for researchers in learning analytics, educational data mining, and dropout prediction.
+**Agent-based simulation environment for Open & Distance Learning (ODL) research.** SynthEd generates behaviorally grounded and temporally coherent learning trajectories by combining persona-driven agent modeling with 10 established theoretical frameworks. Built for researchers in learning analytics, educational data mining, and dropout prediction.
 
 ```bash
 pip install -e ".[dev]"

--- a/docs/THEORY.md
+++ b/docs/THEORY.md
@@ -74,7 +74,7 @@ SynthEd's persona attributes and simulation mechanics are grounded in eleven est
 | # | Anchor | Origin | Role in SynthEd |
 |---|--------|--------|-----------------|
 | 1 | **Tinto's Student Integration Model** (1975) | Sociology (Durkheim) | Academic & social integration drive engagement. Social integration weighted lower in ODE context. |
-| 2 | **Bean & Metzner** (1985) | Non-traditional students | Environmental factors (work, family, finances) are the **dominant** dropout predictors in ODE. |
+| 2 | **Bean & Metzner** (1985) | Non-traditional students | Environmental factors (work, family, finances) are the **dominant** dropout predictors in ODE. Includes stochastic unavoidable withdrawal events (illness, death, relocation) via Lazarus & Folkman's (1984) stress-coping framework. |
 | 3 | **Kember's Process Model** (1989) | Distance education | Dynamic `perceived_cost_benefit` updated weekly based on academic outcomes. |
 | 4 | **Moore's Transactional Distance** (1993) | Distance education | Course structure and dialogue interact with learner autonomy. |
 | 5 | **Self-Determination Theory** (Deci & Ryan, 1985) | Psychology | Intrinsic/extrinsic motivation and amotivation predict persistence. |
@@ -83,7 +83,6 @@ SynthEd's persona attributes and simulation mechanics are grounded in eleven est
 | 8 | **Baulke et al. Phase Model** (2022) | Psychology | 6-phase dropout process: non-fit perception -> thoughts -> deliberation -> info search -> decision. Phase thresholds modulated by `support_services_quality` via `scale_by()`. |
 | 9 | **Epstein & Axtell ABSS** (1996) | Computational social science | Bottom-up emergent behavior: peer networks, engagement contagion, dropout cascades. |
 | 10 | **Academic Exhaustion** (Gonzalez et al., 2025) | Psychology | Exhaustion as mediator between stressors and dropout risk. |
-| 11 | **Unavoidable Withdrawal** | Life-event modeling | Stochastic life events (illness, death, relocation) forcing involuntary withdrawal. |
 
 ---
 
@@ -166,7 +165,7 @@ SynthEd/
 │   │   ├── social_network.py    # Peer network with link decay
 │   │   ├── semester.py          # Multi-semester with carry-over
 │   │   ├── institutional.py     # InstitutionalConfig (5 quality parameters)
-│   │   └── theories/            # 11 modules, one per theoretical framework
+│   │   └── theories/            # 10 theory modules + unavoidable withdrawal mechanism
 │   ├── data_output/
 │   │   ├── exporter.py          # CSV export (4 standard files)
 │   │   ├── oulad_exporter.py    # OULAD-compatible 7-table export
@@ -233,7 +232,7 @@ Quality grades: **A** (90%+), **B** (75%+), **C** (60%+), **D** (40%+), **F** (<
 | `test_factory.py` | 26 | Population, seed determinism, attribute ranges, display_id |
 | `test_engine.py` | 12 | State, phases, engagement, dropout, std_engagement |
 | `test_social_network.py` | 11 | Links, degree, peer influence, decay, statistics |
-| `test_theories.py` | 29 | All 11 theory modules, GPA feedback, coping, disability |
+| `test_theories.py` | 29 | All 10 theory modules + unavoidable withdrawal, GPA feedback, coping, disability |
 | `test_pipeline_integration.py` | 11 | Full pipeline, validation, calibration, profiles |
 | `test_semester.py` | 19 | Carry-over, dropout persistence, prior_gpa blend |
 | `test_llm_enrichment.py` | 12 | Mock LLM, backstory export, error handling |

--- a/docs/THEORY.md
+++ b/docs/THEORY.md
@@ -69,7 +69,7 @@ flowchart TD
 
 ## 📚 Theoretical Anchors
 
-SynthEd's persona attributes and simulation mechanics are grounded in eleven established theoretical frameworks from ODE dropout research:
+SynthEd's persona attributes and simulation mechanics are grounded in ten established theoretical frameworks from ODE dropout research:
 
 | # | Anchor | Origin | Role in SynthEd |
 |---|--------|--------|-----------------|


### PR DESCRIPTION
## Summary
- Unavoidable Withdrawal is a stochastic mechanism, not a theoretical framework
- Merged into Bean & Metzner row with Lazarus & Folkman (1984) stress-coping reference
- All "11 theory" references updated to "10" in README and THEORY.md

## Test plan
- [x] 697 tests pass
- [x] doc_facts consistent
- [x] No code changes — docs only