### PR TITLE
refactor: extract SimulationState dataclasses to simulation/state.py (Architect Rec 3)

### DIFF
--- a/synthed/data_output/exporter.py
+++ b/synthed/data_output/exporter.py
@@ -11,7 +11,7 @@ import csv
 from pathlib import Path
 
 from ..agents.persona import StudentPersona
-from ..simulation.engine import InteractionRecord, SimulationState
+from ..simulation.state import InteractionRecord, SimulationState
 from ..simulation.social_network import SocialNetwork
 
 

--- a/synthed/data_output/oulad_exporter.py
+++ b/synthed/data_output/oulad_exporter.py
@@ -26,7 +26,7 @@ from .oulad_mappings import (
 
 if TYPE_CHECKING:
     from ..agents.persona import StudentPersona
-    from ..simulation.engine import InteractionRecord, SimulationState
+    from ..simulation.state import InteractionRecord, SimulationState
     from ..simulation.environment import ODLEnvironment
 
 logger = logging.getLogger(__name__)

--- a/synthed/simulation/engine.py
+++ b/synthed/simulation/engine.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import logging
 import random
-from dataclasses import dataclass, field
 from typing import Any
 
 import numpy as np
@@ -48,86 +47,13 @@ from .theories import (
     SDTNeedSatisfaction,
     PositiveEventHandler,
     GonzalezExhaustion,
-    ExhaustionState,
     UnavoidableWithdrawal,
     discover_theories,
 )
 from .theories.protocol import TheoryContext
+from .state import CommunityOfInquiryState, SimulationState, InteractionRecord
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class InteractionRecord:
-    """A single interaction event in the simulation."""
-    student_id: str
-    week: int
-    course_id: str
-    interaction_type: str  # lms_login, forum_post, forum_read, assignment_submit, live_session, exam
-    timestamp_offset_hours: float = 0.0
-    duration_minutes: float = 0.0
-    quality_score: float = 0.0  # 0-1, for assignments/exams
-    metadata: dict[str, Any] = field(default_factory=dict)
-
-
-@dataclass
-class CommunityOfInquiryState:
-    """Garrison et al. (2000): Three presences tracked per student."""
-    social_presence: float = 0.3       # 0-1; perceived connection to learning community
-    cognitive_presence: float = 0.4    # 0-1; depth of meaning-making in discourse
-    teaching_presence: float = 0.5     # 0-1; perceived instructor design + facilitation
-
-
-@dataclass
-class SimulationState:
-    """Tracks evolving state of a student across the simulation."""
-    student_id: str
-    current_engagement: float = 0.5
-    academic_integration: float = 0.5  # Tinto: evolves with performance
-    social_integration: float = 0.3  # Tinto: evolves with interaction
-    perceived_cost_benefit: float = 0.6  # Kember: evolves with experience
-    dropout_phase: int = 0  # Bäulke: 0–5
-    cumulative_gpa: float = 0.0
-    gpa_points_sum: float = 0.0  # running sum of quality scores scaled to 4.0
-    gpa_count: int = 0           # number of graded items (assignments + exams)
-    perceived_mastery_sum: float = 0.0   # running sum of raw quality (uninflated)
-    perceived_mastery_count: int = 0     # number of graded items for mastery track
-    courses_active: list[str] = field(default_factory=list)
-    has_dropped_out: bool = False
-    dropout_week: int | None = None
-    withdrawal_reason: str | None = None
-    weekly_engagement_history: list[float] = field(default_factory=list)
-    missed_assignments_streak: int = 0  # Consecutive missed assignments
-    # Garrison et al. (2000): Community of Inquiry
-    coi_state: CommunityOfInquiryState = field(default_factory=CommunityOfInquiryState)
-    # Deci & Ryan (1985): Self-Determination Theory
-    sdt_needs: SDTNeedSatisfaction = field(default_factory=SDTNeedSatisfaction)
-    current_motivation_type: str = "extrinsic"
-    # Gonzalez et al. (2025): Academic exhaustion as mediator
-    exhaustion: ExhaustionState = field(default_factory=ExhaustionState)
-    # Bean & Metzner coping adaptation (Lazarus & Folkman, 1984)
-    coping_factor: float = 0.0  # 0.0-0.5; reduces environmental pressure impact
-    # Environmental shocks (Bean & Metzner: acute life events)
-    env_shock_remaining: int = 0        # weeks remaining for active shock
-    env_shock_magnitude: float = 0.0    # engagement penalty per week during shock
-    # Temporal memory (moved from StudentPersona to avoid mutating input)
-    memory: list[dict[str, Any]] = field(default_factory=list)
-    # ── Grading state ──
-    midterm_exam_scores: list[float] = field(default_factory=list)
-    assignment_scores: list[float] = field(default_factory=list)
-    forum_scores: list[float] = field(default_factory=list)
-    final_score: float | None = None
-    semester_grade: float | None = None  # raw quality [0-1], NOT floor-adjusted
-    outcome: str | None = None
-    n_total_assignments: int = 0
-    n_total_forums: int = 0
-
-    @property
-    def perceived_mastery(self) -> float:
-        """Raw quality average (uninflated by grade floor). Returns 0.5 when no items recorded."""
-        if self.perceived_mastery_count == 0:
-            return 0.5
-        return self.perceived_mastery_sum / self.perceived_mastery_count
 
 
 class SimulationEngine:

--- a/synthed/simulation/semester.py
+++ b/synthed/simulation/semester.py
@@ -22,10 +22,8 @@ from typing import Any
 import numpy as np
 
 from ..agents.persona import StudentPersona
-from .engine import (
-    SimulationEngine, InteractionRecord, SimulationState,
-    CommunityOfInquiryState,
-)
+from .engine import SimulationEngine
+from .state import CommunityOfInquiryState, InteractionRecord, SimulationState
 from .social_network import SocialNetwork
 from .theories import ExhaustionState
 

--- a/synthed/simulation/state.py
+++ b/synthed/simulation/state.py
@@ -1,0 +1,85 @@
+"""
+Simulation state dataclasses.
+
+Extracted from engine.py to keep that module focused on orchestration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .theories import ExhaustionState, SDTNeedSatisfaction
+
+
+@dataclass
+class InteractionRecord:
+    """A single interaction event in the simulation."""
+    student_id: str
+    week: int
+    course_id: str
+    interaction_type: str  # lms_login, forum_post, forum_read, assignment_submit, live_session, exam
+    timestamp_offset_hours: float = 0.0
+    duration_minutes: float = 0.0
+    quality_score: float = 0.0  # 0-1, for assignments/exams
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class CommunityOfInquiryState:
+    """Garrison et al. (2000): Three presences tracked per student."""
+    social_presence: float = 0.3       # 0-1; perceived connection to learning community
+    cognitive_presence: float = 0.4    # 0-1; depth of meaning-making in discourse
+    teaching_presence: float = 0.5     # 0-1; perceived instructor design + facilitation
+
+
+@dataclass
+class SimulationState:
+    """Tracks evolving state of a student across the simulation."""
+    student_id: str
+    current_engagement: float = 0.5
+    academic_integration: float = 0.5  # Tinto: evolves with performance
+    social_integration: float = 0.3  # Tinto: evolves with interaction
+    perceived_cost_benefit: float = 0.6  # Kember: evolves with experience
+    dropout_phase: int = 0  # Bäulke: 0–5
+    cumulative_gpa: float = 0.0
+    gpa_points_sum: float = 0.0  # running sum of quality scores scaled to 4.0
+    gpa_count: int = 0           # number of graded items (assignments + exams)
+    perceived_mastery_sum: float = 0.0   # running sum of raw quality (uninflated)
+    perceived_mastery_count: int = 0     # number of graded items for mastery track
+    courses_active: list[str] = field(default_factory=list)
+    has_dropped_out: bool = False
+    dropout_week: int | None = None
+    withdrawal_reason: str | None = None
+    weekly_engagement_history: list[float] = field(default_factory=list)
+    missed_assignments_streak: int = 0  # Consecutive missed assignments
+    # Garrison et al. (2000): Community of Inquiry
+    coi_state: CommunityOfInquiryState = field(default_factory=CommunityOfInquiryState)
+    # Deci & Ryan (1985): Self-Determination Theory
+    sdt_needs: SDTNeedSatisfaction = field(default_factory=SDTNeedSatisfaction)
+    current_motivation_type: str = "extrinsic"
+    # Gonzalez et al. (2025): Academic exhaustion as mediator
+    exhaustion: ExhaustionState = field(default_factory=ExhaustionState)
+    # Bean & Metzner coping adaptation (Lazarus & Folkman, 1984)
+    coping_factor: float = 0.0  # 0.0-0.5; reduces environmental pressure impact
+    # Environmental shocks (Bean & Metzner: acute life events)
+    env_shock_remaining: int = 0        # weeks remaining for active shock
+    env_shock_magnitude: float = 0.0    # engagement penalty per week during shock
+    # Temporal memory (moved from StudentPersona to avoid mutating input)
+    memory: list[dict[str, Any]] = field(default_factory=list)
+    # ── Grading state ──
+    midterm_exam_scores: list[float] = field(default_factory=list)
+    assignment_scores: list[float] = field(default_factory=list)
+    forum_scores: list[float] = field(default_factory=list)
+    final_score: float | None = None
+    semester_grade: float | None = None  # raw quality [0-1], NOT floor-adjusted
+    outcome: str | None = None
+    n_total_assignments: int = 0
+    n_total_forums: int = 0
+
+    @property
+    def perceived_mastery(self) -> float:
+        """Raw quality average (uninflated by grade floor). Returns 0.5 when no items recorded."""
+        if self.perceived_mastery_count == 0:
+            return 0.5
+        return self.perceived_mastery_sum / self.perceived_mastery_count

--- a/synthed/simulation/statistics.py
+++ b/synthed/simulation/statistics.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 if TYPE_CHECKING:
-    from .engine import SimulationState
+    from .state import SimulationState
 
 logger = logging.getLogger(__name__)
 

--- a/synthed/simulation/theories/academic_exhaustion.py
+++ b/synthed/simulation/theories/academic_exhaustion.py
@@ -9,7 +9,7 @@ import numpy as np
 from ..institutional import InstitutionalConfig, scale_by
 
 if TYPE_CHECKING:
-    from ..engine import InteractionRecord, SimulationState
+    from ..state import InteractionRecord, SimulationState
     from ...agents.persona import StudentPersona
 
 

--- a/synthed/simulation/theories/baulke.py
+++ b/synthed/simulation/theories/baulke.py
@@ -9,7 +9,7 @@ from ..institutional import InstitutionalConfig, scale_by
 
 if TYPE_CHECKING:
     from ...agents.persona import StudentPersona
-    from ..engine import SimulationState
+    from ..state import SimulationState
     from .protocol import TheoryContext
     from ..environment import ODLEnvironment
 

--- a/synthed/simulation/theories/bean_metzner.py
+++ b/synthed/simulation/theories/bean_metzner.py
@@ -7,7 +7,7 @@ import numpy as np
 
 if TYPE_CHECKING:
     from ...agents.persona import StudentPersona
-    from ..engine import SimulationState
+    from ..state import SimulationState
 
 
 class BeanMetznerPressure:

--- a/synthed/simulation/theories/epstein_axtell.py
+++ b/synthed/simulation/theories/epstein_axtell.py
@@ -7,7 +7,7 @@ import numpy as np
 
 if TYPE_CHECKING:
     from ...agents.persona import StudentPersona
-    from ..engine import InteractionRecord, SimulationState
+    from ..state import InteractionRecord, SimulationState
     from ..social_network import SocialNetwork
     from .protocol import TheoryContext
 

--- a/synthed/simulation/theories/garrison_coi.py
+++ b/synthed/simulation/theories/garrison_coi.py
@@ -7,7 +7,7 @@ import numpy as np
 
 if TYPE_CHECKING:
     from ...agents.persona import StudentPersona
-    from ..engine import InteractionRecord, SimulationState
+    from ..state import InteractionRecord, SimulationState
     from .protocol import TheoryContext
     from ..environment import Course
 

--- a/synthed/simulation/theories/kember.py
+++ b/synthed/simulation/theories/kember.py
@@ -9,7 +9,7 @@ from ..institutional import InstitutionalConfig, scale_by
 
 if TYPE_CHECKING:
     from ...agents.persona import StudentPersona
-    from ..engine import InteractionRecord, SimulationState
+    from ..state import InteractionRecord, SimulationState
 
 
 class KemberCostBenefit:

--- a/synthed/simulation/theories/moore_td.py
+++ b/synthed/simulation/theories/moore_td.py
@@ -7,7 +7,7 @@ import numpy as np
 
 if TYPE_CHECKING:
     from ...agents.persona import StudentPersona
-    from ..engine import SimulationState
+    from ..state import SimulationState
     from ..environment import Course, ODLEnvironment
 
 

--- a/synthed/simulation/theories/positive_events.py
+++ b/synthed/simulation/theories/positive_events.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ..engine import SimulationState
+    from ..state import SimulationState
     from ...agents.persona import StudentPersona
 
 

--- a/synthed/simulation/theories/protocol.py
+++ b/synthed/simulation/theories/protocol.py
@@ -22,7 +22,7 @@ import numpy as np
 
 if TYPE_CHECKING:
     from ...agents.persona import StudentPersona
-    from ..engine import InteractionRecord, SimulationState
+    from ..state import InteractionRecord, SimulationState
     from ..engine_config import EngineConfig
     from ..environment import Course, ODLEnvironment
     from ..institutional import InstitutionalConfig

--- a/synthed/simulation/theories/sdt_motivation.py
+++ b/synthed/simulation/theories/sdt_motivation.py
@@ -8,7 +8,7 @@ import numpy as np
 
 if TYPE_CHECKING:
     from ...agents.persona import StudentPersona
-    from ..engine import InteractionRecord, SimulationState
+    from ..state import InteractionRecord, SimulationState
     from .protocol import TheoryContext
 
 

--- a/synthed/simulation/theories/tinto.py
+++ b/synthed/simulation/theories/tinto.py
@@ -7,7 +7,7 @@ import numpy as np
 
 if TYPE_CHECKING:
     from ...agents.persona import StudentPersona
-    from ..engine import InteractionRecord, SimulationState
+    from ..state import InteractionRecord, SimulationState
     from .protocol import TheoryContext
 
 

--- a/synthed/simulation/theories/unavoidable_withdrawal.py
+++ b/synthed/simulation/theories/unavoidable_withdrawal.py
@@ -17,7 +17,7 @@ import numpy as np
 if TYPE_CHECKING:
     from numpy.random import Generator
 
-    from ..engine import SimulationState
+    from ..state import SimulationState
     from ...agents.persona import StudentPersona
 
 logger = logging.getLogger(__name__)

--- a/tests/test_coverage_boost.py
+++ b/tests/test_coverage_boost.py
@@ -18,10 +18,7 @@ import numpy as np
 from synthed.agents.persona import StudentPersona
 from synthed.data_output.exporter import DataExporter
 from synthed.pipeline import SynthEdPipeline
-from synthed.simulation.engine import (
-    SimulationState,
-    CommunityOfInquiryState,
-)
+from synthed.simulation.state import SimulationState, CommunityOfInquiryState
 from synthed.simulation.environment import ODLEnvironment, _default_semester_name
 from synthed.simulation.theories.baulke import BaulkeDropoutPhase
 from synthed.simulation.theories.positive_events import PositiveEventHandler

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -57,7 +57,8 @@ class TestBaulkeEdgeCases:
     def test_phase_transition_with_low_gpa(self):
         """Baulke non-fit perception triggered by low GPA."""
         from synthed.agents.persona import StudentPersona, BigFiveTraits
-        from synthed.simulation.engine import SimulationEngine, SimulationState
+        from synthed.simulation.engine import SimulationEngine
+        from synthed.simulation.state import SimulationState
         from synthed.simulation.environment import ODLEnvironment
 
         env = ODLEnvironment()

--- a/tests/test_dual_track_gpa.py
+++ b/tests/test_dual_track_gpa.py
@@ -1,7 +1,8 @@
 """Tests for dual-track GPA: transcript GPA vs perceived mastery."""
 import numpy as np
 
-from synthed.simulation.engine import SimulationState, SimulationEngine
+from synthed.simulation.engine import SimulationEngine
+from synthed.simulation.state import SimulationState
 from synthed.simulation.environment import ODLEnvironment
 from synthed.simulation.theories.kember import KemberCostBenefit
 from synthed.simulation.theories.sdt_motivation import SDTMotivationDynamics, SDTNeedSatisfaction
@@ -70,7 +71,7 @@ class TestKemberUsesPerceivedMastery:
         state.perceived_mastery_count = 5
         initial_cb = state.perceived_cost_benefit
         # neutral quality record so quality factor doesn't dominate
-        from synthed.simulation.engine import InteractionRecord
+        from synthed.simulation.state import InteractionRecord
         records = [
             InteractionRecord(student_id="test-001", week=5, course_id="CS101",
                               interaction_type="assignment_submit", quality_score=0.5),
@@ -94,7 +95,7 @@ class TestKemberUsesPerceivedMastery:
         )
         state.perceived_mastery_sum = 4.0   # mastery = 0.8
         state.perceived_mastery_count = 5
-        from synthed.simulation.engine import InteractionRecord
+        from synthed.simulation.state import InteractionRecord
         records = [
             InteractionRecord(student_id="test-001", week=5, course_id="CS101",
                               interaction_type="assignment_submit", quality_score=0.5),
@@ -120,7 +121,7 @@ class TestSDTUsesPerceivedMastery:
         state.sdt_needs = SDTNeedSatisfaction(competence=0.5)
         state.perceived_mastery_sum = 1.5   # mastery = 0.3
         state.perceived_mastery_count = 5
-        from synthed.simulation.engine import InteractionRecord
+        from synthed.simulation.state import InteractionRecord
         records = [
             InteractionRecord(student_id="test-001", week=5, course_id="CS101",
                               interaction_type="assignment_submit", quality_score=0.5),
@@ -143,7 +144,7 @@ class TestSDTUsesPerceivedMastery:
         state.sdt_needs = SDTNeedSatisfaction(competence=0.5)
         state.perceived_mastery_sum = 4.0   # mastery = 0.8
         state.perceived_mastery_count = 5
-        from synthed.simulation.engine import InteractionRecord
+        from synthed.simulation.state import InteractionRecord
         records = [
             InteractionRecord(student_id="test-001", week=5, course_id="CS101",
                               interaction_type="assignment_submit", quality_score=0.5),

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -99,7 +99,7 @@ class TestSimulationEngine:
 
     def test_summary_statistics_with_unavoidable_withdrawals(self):
         """summary_statistics handles withdrawal_reason in phase_dist (lines 574, 585)."""
-        from synthed.simulation.engine import SimulationState
+        from synthed.simulation.state import SimulationState
 
         states = {
             "s1": SimulationState(
@@ -136,7 +136,7 @@ class TestSimulationEngine:
 
     def test_summary_includes_std_final_engagement(self):
         """summary_statistics returns std_final_engagement for retained students."""
-        from synthed.simulation.engine import SimulationState
+        from synthed.simulation.state import SimulationState
 
         states = {
             "s1": SimulationState(
@@ -165,7 +165,7 @@ class TestSimulationEngine:
 
     def test_std_final_engagement_none_when_all_dropout(self):
         """std_final_engagement is None when all students dropped out."""
-        from synthed.simulation.engine import SimulationState
+        from synthed.simulation.state import SimulationState
 
         states = {
             "s1": SimulationState(
@@ -192,7 +192,7 @@ class TestSimulationEngine:
         )
 
         # Manually run with a state that has an invalid course ID
-        from synthed.simulation.engine import SimulationState
+        from synthed.simulation.state import SimulationState
         states = {
             student.id: SimulationState(
                 student_id=student.id,

--- a/tests/test_engine_grading.py
+++ b/tests/test_engine_grading.py
@@ -5,7 +5,8 @@ import logging
 
 import numpy as np
 
-from synthed.simulation.engine import SimulationEngine, SimulationState
+from synthed.simulation.engine import SimulationEngine
+from synthed.simulation.state import SimulationState
 from synthed.simulation.environment import ODLEnvironment
 from synthed.simulation.grading import GradingConfig, GradingScale
 from synthed.simulation.institutional import InstitutionalConfig

--- a/tests/test_environmental_shocks.py
+++ b/tests/test_environmental_shocks.py
@@ -6,7 +6,8 @@ import pytest
 
 from synthed.agents.persona import StudentPersona
 from synthed.agents.factory import StudentFactory
-from synthed.simulation.engine import SimulationEngine, SimulationState, CommunityOfInquiryState
+from synthed.simulation.engine import SimulationEngine
+from synthed.simulation.state import SimulationState, CommunityOfInquiryState
 from synthed.simulation.environment import ODLEnvironment
 from synthed.simulation.theories.bean_metzner import BeanMetznerPressure
 from synthed.simulation.theories.baulke import BaulkeDropoutPhase

--- a/tests/test_gpa.py
+++ b/tests/test_gpa.py
@@ -4,7 +4,8 @@ import csv
 
 from synthed.agents.persona import StudentPersona, BigFiveTraits
 from synthed.agents.factory import StudentFactory
-from synthed.simulation.engine import SimulationEngine, SimulationState
+from synthed.simulation.engine import SimulationEngine
+from synthed.simulation.state import SimulationState
 from synthed.simulation.environment import ODLEnvironment
 from synthed.data_output.exporter import DataExporter
 

--- a/tests/test_network_scaling.py
+++ b/tests/test_network_scaling.py
@@ -36,7 +36,7 @@ class TestUpdateNetworkCompat:
         """Call update_network without rng -> works (all-pairs)."""
         ea = EpsteinAxtellPeerInfluence()
         net = SocialNetwork()
-        from synthed.simulation.engine import InteractionRecord
+        from synthed.simulation.state import InteractionRecord
         records = {
             "s1": [InteractionRecord(student_id="s1", week=1, course_id="c1", interaction_type="forum_post")],
             "s2": [InteractionRecord(student_id="s2", week=1, course_id="c1", interaction_type="forum_post")],
@@ -54,7 +54,7 @@ class TestLargeScaleMeanDegree:
         ea = EpsteinAxtellPeerInfluence()
         net = SocialNetwork()
         rng = np.random.default_rng(99)
-        from synthed.simulation.engine import InteractionRecord
+        from synthed.simulation.state import InteractionRecord
         records = {}
         for i in range(200):
             sid = f"student_{i}"

--- a/tests/test_opportunity_cost.py
+++ b/tests/test_opportunity_cost.py
@@ -1,6 +1,6 @@
 """Tests for Kember opportunity cost mechanism."""
 
-from synthed.simulation.engine import SimulationState
+from synthed.simulation.state import SimulationState
 from synthed.simulation.theories.kember import KemberCostBenefit
 from synthed.agents.persona import PersonaConfig
 from synthed.agents.factory import StudentFactory

--- a/tests/test_semester.py
+++ b/tests/test_semester.py
@@ -129,7 +129,7 @@ class TestCarryOverStateNone:
     def test_carry_over_skips_student_without_state(self):
         """Student not in states dict is skipped in carry-over."""
         from synthed.agents.persona import StudentPersona
-        from synthed.simulation.engine import SimulationState
+        from synthed.simulation.state import SimulationState
         from synthed.simulation.social_network import SocialNetwork
 
         students = [
@@ -170,7 +170,7 @@ class TestBuildInterimReport:
         from synthed.simulation.semester import (
             _build_interim_report, SemesterResult,
         )
-        from synthed.simulation.engine import SimulationState
+        from synthed.simulation.state import SimulationState
 
         # Create mock semester results with no dropouts
         states = {
@@ -190,7 +190,7 @@ class TestBuildInterimReport:
         from synthed.simulation.semester import (
             _build_interim_report, SemesterResult,
         )
-        from synthed.simulation.engine import SimulationState
+        from synthed.simulation.state import SimulationState
 
         # All students dropped out
         states = {
@@ -210,7 +210,7 @@ class TestBuildInterimReport:
         from synthed.simulation.semester import (
             _build_interim_report, SemesterResult,
         )
-        from synthed.simulation.engine import SimulationState
+        from synthed.simulation.state import SimulationState
 
         # 5 out of 10 dropped out = 50%, target is 40-60%
         states = {}
@@ -239,7 +239,7 @@ class TestPriorGPABlend:
     def test_prior_gpa_blend_updates_persona(self):
         """Earned GPA blends into prior_gpa with default alpha=0.6."""
         from synthed.agents.persona import StudentPersona
-        from synthed.simulation.engine import SimulationState
+        from synthed.simulation.state import SimulationState
         from synthed.simulation.semester import _create_carry_over_persona, SemesterCarryOverConfig
 
         student = StudentPersona(prior_gpa=3.0)
@@ -260,7 +260,7 @@ class TestPriorGPABlend:
     def test_prior_gpa_no_blend_when_no_grades(self):
         """With gpa_count=0, prior_gpa stays unchanged."""
         from synthed.agents.persona import StudentPersona
-        from synthed.simulation.engine import SimulationState
+        from synthed.simulation.state import SimulationState
         from synthed.simulation.semester import _create_carry_over_persona, SemesterCarryOverConfig
 
         student = StudentPersona(prior_gpa=3.0)
@@ -280,7 +280,7 @@ class TestPriorGPABlend:
     def test_prior_gpa_blend_respects_alpha(self):
         """alpha=0 keeps original, alpha=1 fully replaces."""
         from synthed.agents.persona import StudentPersona
-        from synthed.simulation.engine import SimulationState
+        from synthed.simulation.state import SimulationState
         from synthed.simulation.semester import _create_carry_over_persona, SemesterCarryOverConfig
 
         student = StudentPersona(prior_gpa=3.0)
@@ -305,7 +305,7 @@ class TestPriorGPABlend:
     def test_prior_gpa_blend_clamps_to_range(self):
         """Blended prior_gpa is clipped to [0.0, 4.0]."""
         from synthed.agents.persona import StudentPersona
-        from synthed.simulation.engine import SimulationState
+        from synthed.simulation.state import SimulationState
         from synthed.simulation.semester import _create_carry_over_persona, SemesterCarryOverConfig
 
         student = StudentPersona(prior_gpa=3.5)
@@ -348,7 +348,7 @@ class TestCopingCarryOver:
 
     def test_coping_retention_in_carry_over(self):
         """Coping factor is partially retained via _build_state_overrides."""
-        from synthed.simulation.engine import SimulationState
+        from synthed.simulation.state import SimulationState
         from synthed.simulation.semester import _build_state_overrides, SemesterCarryOverConfig
 
         state = SimulationState(

--- a/tests/test_social_network.py
+++ b/tests/test_social_network.py
@@ -1,7 +1,7 @@
 """Tests for SocialNetwork."""
 
 from synthed.simulation.social_network import SocialNetwork
-from synthed.simulation.engine import SimulationState
+from synthed.simulation.state import SimulationState
 
 
 class TestSocialNetwork:

--- a/tests/test_theories.py
+++ b/tests/test_theories.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 from synthed.agents.persona import StudentPersona, BigFiveTraits
-from synthed.simulation.engine import InteractionRecord, SimulationState, CommunityOfInquiryState
+from synthed.simulation.state import InteractionRecord, SimulationState, CommunityOfInquiryState
 from synthed.simulation.environment import ODLEnvironment
 from synthed.simulation.theories import (
     TintoIntegration,

--- a/tests/test_unavoidable_withdrawal.py
+++ b/tests/test_unavoidable_withdrawal.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from synthed.agents.persona import StudentPersona, PersonaConfig
-from synthed.simulation.engine import SimulationState, CommunityOfInquiryState
+from synthed.simulation.state import SimulationState, CommunityOfInquiryState
 from synthed.simulation.theories import (
     SDTNeedSatisfaction,
     ExhaustionState,


### PR DESCRIPTION
## Summary
Architect recommendation #3 — extract data model from orchestrator module.

- Moved `SimulationState`, `CommunityOfInquiryState`, `InteractionRecord` from `engine.py` to new `simulation/state.py`
- Updated 14 import sites across data_output, theories, analysis, and engine itself
- `engine.py`: 832 → 760 lines (-72)
- `state.py`: 85 lines (new)

## Why
- Breaks circular-import pressure (theories no longer reach into engine for data types)
- Engine.py becomes pure orchestration, not data model + orchestration
- Prerequisite for Rec 2 (grading extraction)

## Test plan
- [x] 714 tests pass
- [x] ruff clean
- [x] No behavior change — pure refactor