### PR TITLE
refactor: extract grading orchestration to grading.py (Architect Rec 2)

### DIFF
--- a/synthed/simulation/engine.py
+++ b/synthed/simulation/engine.py
@@ -29,11 +29,7 @@ from .engine_config import EngineConfig
 from .environment import ODLEnvironment
 from .grading import (
     GradingConfig,
-    apply_relative_grading,
-    calculate_semester_grade,
-    check_dual_hurdle_pass,
-    classify_outcome as _classify_outcome,
-    normalize_t_scores,
+    assign_outcomes as _assign_outcomes,
 )
 from .institutional import InstitutionalConfig, scale_by
 from .social_network import SocialNetwork
@@ -265,7 +261,7 @@ class SimulationEngine:
                     state.dropout_week = week
 
         # ── End-of-run: semester grade and outcome assignment ──
-        self._assign_outcomes(states)
+        _assign_outcomes(states, self.grading_config, self.cfg, self.rng)
 
         return all_records, states, self.network
 
@@ -286,172 +282,6 @@ class SimulationEngine:
         state.cumulative_gpa = state.gpa_points_sum / state.gpa_count
         state.perceived_mastery_sum += quality
         state.perceived_mastery_count += 1
-
-    def _compute_midterm_aggregate(self, state: SimulationState, cfg: GradingConfig) -> float:
-        """Compute weighted midterm aggregate from component scores."""
-        component_data: dict[str, tuple[list[float], int]] = {
-            "exam": (state.midterm_exam_scores, len(state.midterm_exam_scores)),
-            "assignment": (state.assignment_scores, max(state.n_total_assignments, len(state.assignment_scores))),
-            "forum": (state.forum_scores, max(state.n_total_forums, len(state.forum_scores))),
-        }
-        total = 0.0
-        for comp_name, weight in cfg.midterm_components.items():
-            scores, n = component_data.get(comp_name, ([], 0))
-            comp_mean = sum(scores) / max(n, 1) if scores else 0.0
-            total += comp_mean * weight
-        return total
-
-    def _classify_absolute_single(
-        self, state: SimulationState, cfg: GradingConfig, floor: float,
-        grade: float,
-    ) -> str:
-        """Classify a single student using absolute grading (floor-adjust + hurdle + classify).
-
-        Returns the outcome string: Distinction, Pass, or Fail.
-        """
-        adjusted_grade = floor + (1.0 - floor) * grade
-        midterm_agg = self._compute_midterm_aggregate(state, cfg)
-        adjusted_midterm = floor + (1.0 - floor) * midterm_agg
-        adjusted_final = (
-            (floor + (1.0 - floor) * state.final_score)
-            if state.final_score is not None
-            else None
-        )
-        passes_hurdle = check_dual_hurdle_pass(cfg, adjusted_midterm, adjusted_final)
-        if passes_hurdle:
-            return _classify_outcome(adjusted_grade, cfg)
-        return "Fail"
-
-    def _assign_outcomes(self, states: dict[str, SimulationState]) -> None:
-        """Assign semester_grade and outcome to each student at end of run.
-
-        Dispatches to absolute or relative grading based on grading_config.
-        """
-        if self.grading_config.grading_method == "relative":
-            self._assign_outcomes_relative(states)
-        else:
-            self._assign_outcomes_absolute(states)
-
-    def _filter_eligible_states(
-        self,
-        states: dict[str, SimulationState],
-        cfg: GradingConfig,
-        floor: float,
-    ) -> dict[str, float]:
-        """Compute semester_grade and filter eligible students.
-
-        Sets outcome for ineligible students (Withdrawn, Fail).
-        Returns dict of sid -> raw [0-1] semester_grade, NOT floor-adjusted.
-        """
-        eligible: dict[str, float] = {}
-        for sid, state in states.items():
-            if state.has_dropped_out:
-                state.outcome = "Withdrawn"
-                continue
-            if state.gpa_count == 0:
-                state.outcome = "Fail"
-                continue
-            if cfg.exam_eligibility_threshold is not None:
-                midterm_agg = self._compute_midterm_aggregate(state, cfg)
-                adjusted_midterm = floor + (1.0 - floor) * midterm_agg
-                if adjusted_midterm < cfg.exam_eligibility_threshold:
-                    state.outcome = "Fail"
-                    continue
-            grade = calculate_semester_grade(
-                cfg,
-                midterm_exam_scores=state.midterm_exam_scores,
-                assignment_scores=state.assignment_scores,
-                forum_scores=state.forum_scores,
-                final_score=state.final_score,
-                n_total_assignments=state.n_total_assignments,
-                n_total_forums=state.n_total_forums,
-            )
-            state.semester_grade = grade
-            if grade is not None:
-                eligible[sid] = grade
-            else:
-                state.outcome = "Fail"
-        return eligible
-
-    def _classify_relative(
-        self,
-        states: dict[str, SimulationState],
-        cfg: GradingConfig,
-        floor: float,
-        sids: list[str],
-        normalized: list[float],
-    ) -> None:
-        """Classify students using normalized t-scores with dual-hurdle check."""
-        for sid, norm_score in zip(sids, normalized, strict=True):
-            state = states[sid]
-            midterm_agg = self._compute_midterm_aggregate(state, cfg)
-            adjusted_midterm = floor + (1.0 - floor) * midterm_agg
-            adjusted_final = (
-                (floor + (1.0 - floor) * state.final_score)
-                if state.final_score is not None
-                else None
-            )
-            passes_hurdle = check_dual_hurdle_pass(
-                cfg, adjusted_midterm, adjusted_final,
-            )
-            if passes_hurdle:
-                state.outcome = _classify_outcome(norm_score, cfg)
-            else:
-                state.outcome = "Fail"
-
-    def _assign_outcomes_absolute(self, states: dict[str, SimulationState]) -> None:
-        """Assign semester_grade and outcome using absolute grading.
-
-        Thresholds (pass_threshold, distinction_threshold, component_pass_thresholds)
-        are on the transcript scale (floor-adjusted). Raw quality is converted via
-        ``floor + (1 - floor) * raw`` before comparison.
-        """
-        cfg = self.grading_config
-        floor = cfg.grade_floor
-        eligible = self._filter_eligible_states(states, cfg, floor)
-        for sid, grade in eligible.items():
-            states[sid].outcome = self._classify_absolute_single(
-                states[sid], cfg, floor, grade,
-            )
-
-    def _assign_outcomes_relative(self, states: dict[str, SimulationState]) -> None:
-        """Assign semester_grade and outcome using relative (t-score) grading.
-
-        Applies t-score standardization and classifies using normalized scores.
-        Falls back to absolute if fewer than 2 eligible or zero variance.
-        """
-        cfg = self.grading_config
-        floor = cfg.grade_floor
-        eligible = self._filter_eligible_states(states, cfg, floor)
-
-        if len(eligible) < 2:
-            logger.warning(
-                "Relative grading: fewer than 2 eligible students, "
-                "falling back to absolute",
-            )
-            for sid, grade in eligible.items():
-                states[sid].outcome = self._classify_absolute_single(
-                    states[sid], cfg, floor, grade,
-                )
-            return
-
-        sids = list(eligible.keys())
-        raw_grades = [eligible[sid] for sid in sids]
-        t_scores = apply_relative_grading(raw_grades)
-        normalized = normalize_t_scores(t_scores)
-
-        if all(abs(t - 50.0) < 1e-9 for t in t_scores):
-            logger.warning(
-                "Relative grading: zero variance in semester grades, "
-                "falling back to absolute",
-            )
-            for sid, grade in eligible.items():
-                states[sid].outcome = self._classify_absolute_single(
-                    states[sid], cfg, floor, grade,
-                )
-            return
-
-        self._classify_relative(states, cfg, floor, sids, normalized)
 
     def _simulate_student_week(
         self, student: StudentPersona, state: SimulationState,

--- a/synthed/simulation/engine.py
+++ b/synthed/simulation/engine.py
@@ -261,7 +261,7 @@ class SimulationEngine:
                     state.dropout_week = week
 
         # ── End-of-run: semester grade and outcome assignment ──
-        _assign_outcomes(states, self.grading_config, self.cfg, self.rng)
+        _assign_outcomes(states, self.grading_config)
 
         return all_records, states, self.network
 

--- a/synthed/simulation/grading.py
+++ b/synthed/simulation/grading.py
@@ -16,7 +16,6 @@ import numpy as np
 
 if TYPE_CHECKING:
     from .state import SimulationState
-    from .engine_config import EngineConfig
 
 logger = logging.getLogger(__name__)
 
@@ -452,14 +451,10 @@ def _assign_outcomes_relative(
 def assign_outcomes(
     states: dict[str, SimulationState],
     grading_config: GradingConfig,
-    engine_config: EngineConfig | None = None,
-    rng: np.random.Generator | None = None,
 ) -> None:
     """Assign semester_grade and outcome to each student at end of run.
 
     Dispatches to absolute or relative grading based on grading_config.
-    ``engine_config`` and ``rng`` are accepted for API symmetry but currently
-    unused — all logic depends only on grading_config.
     """
     if grading_config.grading_method == "relative":
         _assign_outcomes_relative(states, grading_config)

--- a/synthed/simulation/grading.py
+++ b/synthed/simulation/grading.py
@@ -2,6 +2,7 @@
 
 Provides :class:`GradingConfig` (frozen dataclass) for institution-level
 grading policy, scale conversion, and outcome classification utilities.
+Also provides grading orchestration free functions extracted from SimulationEngine.
 """
 from __future__ import annotations
 
@@ -9,8 +10,13 @@ import enum
 import logging
 import math
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 import numpy as np
+
+if TYPE_CHECKING:
+    from .state import SimulationState
+    from .engine_config import EngineConfig
 
 logger = logging.getLogger(__name__)
 
@@ -283,3 +289,179 @@ def check_dual_hurdle_pass(
         if final_score is None or final_score < config.component_pass_thresholds["final"]:
             return False
     return True
+
+
+# ---------------------------------------------------------------------------
+# Grading orchestration — free functions extracted from SimulationEngine
+# ---------------------------------------------------------------------------
+
+
+def _compute_midterm_aggregate(state: SimulationState, cfg: GradingConfig) -> float:
+    """Compute weighted midterm aggregate from component scores."""
+    component_data: dict[str, tuple[list[float], int]] = {
+        "exam": (state.midterm_exam_scores, len(state.midterm_exam_scores)),
+        "assignment": (state.assignment_scores, max(state.n_total_assignments, len(state.assignment_scores))),
+        "forum": (state.forum_scores, max(state.n_total_forums, len(state.forum_scores))),
+    }
+    total = 0.0
+    for comp_name, weight in cfg.midterm_components.items():
+        scores, n = component_data.get(comp_name, ([], 0))
+        comp_mean = sum(scores) / max(n, 1) if scores else 0.0
+        total += comp_mean * weight
+    return total
+
+
+def _filter_eligible_states(
+    states: dict[str, SimulationState],
+    cfg: GradingConfig,
+    floor: float,
+) -> dict[str, float]:
+    """Compute semester_grade and filter eligible students.
+
+    Sets outcome for ineligible students (Withdrawn, Fail).
+    Returns dict of sid -> raw [0-1] semester_grade, NOT floor-adjusted.
+    """
+    eligible: dict[str, float] = {}
+    for sid, state in states.items():
+        if state.has_dropped_out:
+            state.outcome = "Withdrawn"
+            continue
+        if state.gpa_count == 0:
+            state.outcome = "Fail"
+            continue
+        if cfg.exam_eligibility_threshold is not None:
+            midterm_agg = _compute_midterm_aggregate(state, cfg)
+            adjusted_midterm = floor + (1.0 - floor) * midterm_agg
+            if adjusted_midterm < cfg.exam_eligibility_threshold:
+                state.outcome = "Fail"
+                continue
+        grade = calculate_semester_grade(
+            cfg,
+            midterm_exam_scores=state.midterm_exam_scores,
+            assignment_scores=state.assignment_scores,
+            forum_scores=state.forum_scores,
+            final_score=state.final_score,
+            n_total_assignments=state.n_total_assignments,
+            n_total_forums=state.n_total_forums,
+        )
+        state.semester_grade = grade
+        if grade is not None:
+            eligible[sid] = grade
+        else:
+            state.outcome = "Fail"
+    return eligible
+
+
+def _classify_absolute_single(
+    state: SimulationState, cfg: GradingConfig, floor: float, grade: float,
+) -> str:
+    """Classify a single student using absolute grading (floor-adjust + hurdle + classify).
+
+    Returns the outcome string: Distinction, Pass, or Fail.
+    """
+    adjusted_grade = floor + (1.0 - floor) * grade
+    midterm_agg = _compute_midterm_aggregate(state, cfg)
+    adjusted_midterm = floor + (1.0 - floor) * midterm_agg
+    adjusted_final = (
+        (floor + (1.0 - floor) * state.final_score)
+        if state.final_score is not None
+        else None
+    )
+    passes_hurdle = check_dual_hurdle_pass(cfg, adjusted_midterm, adjusted_final)
+    if passes_hurdle:
+        return classify_outcome(adjusted_grade, cfg)
+    return "Fail"
+
+
+def _classify_relative(
+    states: dict[str, SimulationState],
+    cfg: GradingConfig,
+    floor: float,
+    sids: list[str],
+    normalized: list[float],
+) -> None:
+    """Classify students using normalized t-scores with dual-hurdle check."""
+    for sid, norm_score in zip(sids, normalized, strict=True):
+        state = states[sid]
+        midterm_agg = _compute_midterm_aggregate(state, cfg)
+        adjusted_midterm = floor + (1.0 - floor) * midterm_agg
+        adjusted_final = (
+            (floor + (1.0 - floor) * state.final_score)
+            if state.final_score is not None
+            else None
+        )
+        passes_hurdle = check_dual_hurdle_pass(cfg, adjusted_midterm, adjusted_final)
+        if passes_hurdle:
+            state.outcome = classify_outcome(norm_score, cfg)
+        else:
+            state.outcome = "Fail"
+
+
+def _assign_outcomes_absolute(
+    states: dict[str, SimulationState], grading_config: GradingConfig,
+) -> None:
+    """Assign semester_grade and outcome using absolute grading."""
+    floor = grading_config.grade_floor
+    eligible = _filter_eligible_states(states, grading_config, floor)
+    for sid, grade in eligible.items():
+        states[sid].outcome = _classify_absolute_single(
+            states[sid], grading_config, floor, grade,
+        )
+
+
+def _assign_outcomes_relative(
+    states: dict[str, SimulationState], grading_config: GradingConfig,
+) -> None:
+    """Assign semester_grade and outcome using relative (t-score) grading.
+
+    Falls back to absolute if fewer than 2 eligible or zero variance.
+    """
+    floor = grading_config.grade_floor
+    eligible = _filter_eligible_states(states, grading_config, floor)
+
+    if len(eligible) < 2:
+        logger.warning(
+            "Relative grading: fewer than 2 eligible students, "
+            "falling back to absolute",
+        )
+        for sid, grade in eligible.items():
+            states[sid].outcome = _classify_absolute_single(
+                states[sid], grading_config, floor, grade,
+            )
+        return
+
+    sids = list(eligible.keys())
+    raw_grades = [eligible[sid] for sid in sids]
+    t_scores = apply_relative_grading(raw_grades)
+    normalized = normalize_t_scores(t_scores)
+
+    if all(abs(t - 50.0) < 1e-9 for t in t_scores):
+        logger.warning(
+            "Relative grading: zero variance in semester grades, "
+            "falling back to absolute",
+        )
+        for sid, grade in eligible.items():
+            states[sid].outcome = _classify_absolute_single(
+                states[sid], grading_config, floor, grade,
+            )
+        return
+
+    _classify_relative(states, grading_config, floor, sids, normalized)
+
+
+def assign_outcomes(
+    states: dict[str, SimulationState],
+    grading_config: GradingConfig,
+    engine_config: EngineConfig | None = None,
+    rng: np.random.Generator | None = None,
+) -> None:
+    """Assign semester_grade and outcome to each student at end of run.
+
+    Dispatches to absolute or relative grading based on grading_config.
+    ``engine_config`` and ``rng`` are accepted for API symmetry but currently
+    unused — all logic depends only on grading_config.
+    """
+    if grading_config.grading_method == "relative":
+        _assign_outcomes_relative(states, grading_config)
+    else:
+        _assign_outcomes_absolute(states, grading_config)

--- a/tests/test_engine_grading.py
+++ b/tests/test_engine_grading.py
@@ -8,7 +8,7 @@ import numpy as np
 from synthed.simulation.engine import SimulationEngine
 from synthed.simulation.state import SimulationState
 from synthed.simulation.environment import ODLEnvironment
-from synthed.simulation.grading import GradingConfig, GradingScale
+from synthed.simulation.grading import GradingConfig, GradingScale, assign_outcomes
 from synthed.simulation.institutional import InstitutionalConfig
 
 
@@ -161,8 +161,6 @@ class TestRelativeGrading:
         """All eligible students have identical grades -> fallback warning, outcomes assigned."""
         # Build states manually with identical semester grades
         cfg = GradingConfig(grading_method="relative")
-        env = ODLEnvironment()
-        engine = SimulationEngine(env, seed=42, grading_config=cfg)
 
         states = {}
         for i in range(5):
@@ -176,8 +174,8 @@ class TestRelativeGrading:
             state.final_score = 0.70
             states[sid] = state
 
-        with caplog.at_level(logging.WARNING, logger="synthed.simulation.engine"):
-            engine._assign_outcomes(states)
+        with caplog.at_level(logging.WARNING, logger="synthed.simulation.grading"):
+            assign_outcomes(states, cfg)
 
         assert "zero variance" in caplog.text
         for state in states.values():
@@ -189,8 +187,6 @@ class TestRelativeGrading:
     def test_relative_single_eligible_fallback(self, caplog):
         """1 eligible + rest withdrawn -> fallback to absolute."""
         cfg = GradingConfig(grading_method="relative")
-        env = ODLEnvironment()
-        engine = SimulationEngine(env, seed=42, grading_config=cfg)
 
         states = {}
         # One eligible student
@@ -211,8 +207,8 @@ class TestRelativeGrading:
             state.dropout_week = 3
             states[sid] = state
 
-        with caplog.at_level(logging.WARNING, logger="synthed.simulation.engine"):
-            engine._assign_outcomes(states)
+        with caplog.at_level(logging.WARNING, logger="synthed.simulation.grading"):
+            assign_outcomes(states, cfg)
 
         assert "fewer than 2" in caplog.text
         assert states["S000"].outcome in ("Distinction", "Pass", "Fail")
@@ -222,8 +218,6 @@ class TestRelativeGrading:
     def test_relative_all_withdrawn(self):
         """All dropped out -> all Withdrawn, no crash."""
         cfg = GradingConfig(grading_method="relative")
-        env = ODLEnvironment()
-        engine = SimulationEngine(env, seed=42, grading_config=cfg)
 
         states = {}
         for i in range(5):
@@ -233,7 +227,7 @@ class TestRelativeGrading:
             state.dropout_week = 2
             states[sid] = state
 
-        engine._assign_outcomes(states)
+        assign_outcomes(states, cfg)
         for state in states.values():
             assert state.outcome == "Withdrawn"
 
@@ -244,8 +238,6 @@ class TestRelativeGrading:
             dual_hurdle=True,
             component_pass_thresholds={"final": 0.70},
         )
-        env = ODLEnvironment()
-        engine = SimulationEngine(env, seed=42, grading_config=cfg)
 
         states = {}
         # Student with high midterm but very low final (fails hurdle)
@@ -278,7 +270,7 @@ class TestRelativeGrading:
         s2.final_score = 0.50
         states["S002"] = s2
 
-        engine._assign_outcomes(states)
+        assign_outcomes(states, cfg)
 
         # S000 has highest raw grade but low final -> fails hurdle
         assert states["S000"].outcome == "Fail"


### PR DESCRIPTION
## Summary
7 grading methods moved from `SimulationEngine` into `grading.py` as free functions:
- `assign_outcomes` (public entry), `_assign_outcomes_absolute/relative`, `_filter_eligible_states`, `_classify_absolute_single`, `_classify_relative`, `_compute_midterm_aggregate`
- engine.py: 760 → 590 lines (-170)
- grading.py: 285 → 467 lines (now the complete grading API)
- Zero coupling to engine — takes `(states, grading_config, engine_config, rng)` as args

## Why
- grading.py was half-complete: pure helpers lived there but orchestration was in engine
- engine.py now focuses on orchestration + I/O simulation
- Prerequisite for Rec 1 (engagement protocol unification)

## Test plan
- [x] 714 tests pass
- [x] ruff clean
- [x] No circular imports (grading.py imports from state.py, not engine.py)
- [x] test_engine_grading.py updated to call free functions directly