### PR TITLE
docs: add developer wiki (9 pages with Mermaid diagrams)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ print(f"Dropout: {report['simulation_summary']['dropout_rate']:.1%}")
 |----------|---------|
 | **[User Guide](docs/GUIDE.md)** | Installation, configuration, calibration pipeline, OULAD export, LLM enrichment, troubleshooting |
 | **[Theory & Architecture](docs/THEORY.md)** | 10 theoretical anchors, factor clusters, architecture diagram, project structure, validation suite, test inventory |
+| **[Developer Wiki](docs/wiki/index.md)** | Pipeline internals, simulation loop, engagement formula, theory modules, dropout mechanics, grading, calibration, data export |
 
 ---
 

--- a/docs/wiki/calibration-and-analysis.md
+++ b/docs/wiki/calibration-and-analysis.md
@@ -1,0 +1,469 @@
+# Calibration & Sensitivity Analysis
+
+> **Looking for how to _run_ calibration?** See [GUIDE.md](../GUIDE.md) for CLI usage
+> (`run_calibration.py --quick`, `--workers`, `--profile`). This page explains the
+> internal mechanics, algorithms, and code architecture that power calibration.
+
+SynthEd ships a three-stage calibration pipeline that tunes simulation constants to
+match real-world dropout and GPA distributions. The stages run in sequence:
+
+1. **Sobol sensitivity analysis** -- identifies which parameters matter most
+2. **NSGA-II multi-objective optimization** -- searches the reduced parameter space
+3. **OULAD validation** -- checks calibrated output against held-out real data
+
+All code lives in `synthed/analysis/`.
+
+---
+
+## Architecture Overview
+
+```mermaid
+flowchart LR
+    subgraph "Stage 1: Sensitivity"
+        A[SOBOL_PARAMETER_SPACE<br/>69 params, 13 prefixes] --> B[SobolAnalyzer]
+        B -->|SALib Saltelli sampling| C["N*(D+2) simulations"]
+        C --> D[SobolResult<br/>S1, ST per metric]
+        D --> E[SobolRanking<br/>sorted by ST]
+    end
+
+    subgraph "Stage 2: Optimization"
+        E -->|top-N, exclude config/inst| F[select_nsga2_parameters]
+        F --> G[NSGAIICalibrator]
+        G -->|Optuna NSGAIISampler| H[Pareto front]
+        H --> I[find_knee_point]
+        I --> J[ParetoResult]
+    end
+
+    subgraph "Stage 3: Validation"
+        J --> K[validate_against_oulad]
+        K -->|held-out modules CCC, GGG| L[ValidationReport<br/>grade A/B/C/D]
+    end
+
+    style A fill:#f9f,stroke:#333
+    style J fill:#9f9,stroke:#333
+    style L fill:#ff9,stroke:#333
+```
+
+---
+
+## CalibrationMap
+
+**File:** `synthed/calibration.py`
+
+`CalibrationMap` provides a quick lookup: given a target dropout rate, what
+`dropout_base_rate` should you set in `PersonaConfig`? It uses **piecewise linear
+interpolation** over empirically measured data points.
+
+### How CALIBRATION_DATA was measured
+
+The `CALIBRATION_DATA` tuple contains `CalibrationPoint` entries measured with:
+
+| Setting | Value |
+|---------|-------|
+| Population | N=500 students |
+| Seeds | 5 seeds averaged per point |
+| Persona | Default `PersonaConfig()` (no custom traits) |
+| Date | 2026-04-03 (post `GradingConfig` addition) |
+
+Each point records: `(n_semesters, dropout_base_rate, observed_dropout_rate, n_students, seed_count)`.
+
+### Interpolation logic
+
+```
+CalibrationMap.estimate(target_dropout, n_semesters=1)
+```
+
+1. Filter `CALIBRATION_DATA` to matching `n_semesters`
+2. If fewer than 2 points, fall back to 1-semester data (confidence = `"low"`)
+3. Sort by `observed_dropout_rate`
+4. `np.interp(target_dropout, observed_rates, base_rates)` -- piecewise linear
+5. Clamp result to `[_MIN_BASE_RATE (0.10), _MAX_BASE_RATE (0.95)]`
+6. Return `CalibrationEstimate` with confidence `"high"` (interpolated) or `"low"` (clamped/fallback)
+
+**Example:** Target 45% dropout for 1 semester:
+
+- Two nearest points: `(0.50, 0.442)` and `(0.60, 0.468)`
+- Interpolation yields `dropout_base_rate ~ 0.515`
+- Confidence: `"high"` (within calibrated range)
+
+The `estimate_from_range()` variant takes a `(lower, upper)` tuple, interpolates at
+the midpoint, and sets `validation_tolerance` to half the range width.
+
+### Staleness warning
+
+> `CALIBRATION_DATA` was measured with **default persona traits only**. If you change
+> theory module constants, engine weights, or any RNG-consuming code path (even
+> non-dropout features shift the RNG sequence), the mapping becomes stale.
+> Re-measure by running a sweep of `dropout_base_rate` values across seeds.
+
+---
+
+## Stage 1: Sobol Sensitivity Analysis
+
+**File:** `synthed/analysis/sobol_sensitivity.py`
+
+### The parameter space
+
+`SOBOL_PARAMETER_SPACE` defines **69 parameters** across **13 prefixes**:
+
+| Prefix | Engine attribute | Count | Description |
+|--------|-----------------|-------|-------------|
+| `config` | `PersonaConfig` field | 8 | Population characteristics |
+| `engine` | `EngineConfig` field | 15 | Engagement update weights, quality weights |
+| `bean` | `engine.bean_metzner` | 7 | Environmental pressure |
+| `kember` | `engine.kember` | 6 | Cost-benefit |
+| `baulke` | `engine.baulke` | 6 | Dropout phase thresholds |
+| `inst` | `InstitutionalConfig` field | 5 | Institutional quality |
+| `sdt` | `engine.sdt` | 4 | Motivation dynamics |
+| `gonzalez` | `engine.gonzalez` | 4 | Academic exhaustion |
+| `grading` | `GradingConfig` field | 4 | Grade floor, thresholds, late penalty |
+| `tinto` | `engine.tinto` | 3 | Integration |
+| `rovai` | `engine.rovai` | 3 | Persistence |
+| `garrison` | `engine.garrison` | 2 | Community of Inquiry |
+| `moore` | `engine.moore` | 2 | Transactional distance |
+
+> **Phantom prefix:** `epstein` appears in `MODULE_ALIASES` (mapping to
+> `engine.epstein_axtell`) but **no `SobolParameter` uses it**. The Epstein & Axtell
+> network module's constants are excluded from sensitivity analysis because network
+> formation is structural, not tuneable in the same sense.
+
+### SobolParameter dataclass
+
+Each parameter is a frozen dataclass:
+
+```python
+SobolParameter(
+    name="baulke._NONFIT_ENG_THRESHOLD",  # prefix.attribute
+    lower=0.30,                            # lower bound
+    upper=0.55,                            # upper bound
+    description="Non-fit perception trigger",
+    log_scale=False,                       # Phase 2: Optuna log-uniform
+    step=None,                             # Phase 2: discretization
+)
+```
+
+The `name` follows a strict `prefix.attribute` convention. The prefix determines
+how `_sim_runner` routes the override (see below).
+
+### How the analysis runs
+
+```python
+analyzer = SobolAnalyzer(n_students=200, seed=42)
+results = analyzer.run(n_samples=128)
+rankings = analyzer.rank(results[0])  # rank by dropout_rate ST
+```
+
+**Sampling:** Saltelli method from SALib. With `calc_second_order=False`, total
+simulations = `n_samples * (D + 2)`. Default: `128 * (69 + 2) = 9,088` simulations.
+
+**Output metrics** (3 per run):
+- `dropout_rate`
+- `mean_engagement`
+- `mean_gpa`
+
+**Sobol indices:**
+- **S1 (first-order):** Fraction of output variance explained by this parameter alone
+- **ST (total-order):** Fraction explained by this parameter plus all its interactions
+- **ST - S1:** Pure interaction contribution
+
+**Ranking:** `SobolAnalyzer.rank()` sorts by ST descending. Negative noise values
+are clipped to 0.
+
+### Validation at init time
+
+`SobolAnalyzer._validate_parameters()` runs at construction. It creates a throwaway
+`SimulationEngine` and verifies every parameter name resolves to a real attribute.
+This catches typos before thousands of simulations run.
+
+### Parallel execution
+
+When `n_workers > 1`, simulations run via `ProcessPoolExecutor`. The top-level
+`run_simulation_with_overrides` function (not a lambda or closure) is submitted
+to the pool for pickle safety. Failed simulations return zero-filled metric dicts
+rather than crashing the analysis.
+
+---
+
+## Stage 2: NSGA-II Calibration
+
+**File:** `synthed/analysis/nsga2_calibrator.py`
+
+### Parameter selection
+
+Before optimization, `select_nsga2_parameters()` filters the Sobol rankings:
+
+1. Take the top-N parameters by ST (default `top_n=20`)
+2. **Exclude** `config.*` and `inst.*` prefixes -- these are fixed per benchmark profile
+3. Return matching `SobolParameter` entries from `SOBOL_PARAMETER_SPACE`
+
+This ensures NSGA-II only searches engine/theory/grading constants that the
+researcher does not control directly.
+
+### Two objectives
+
+| Objective | Formula |
+|-----------|---------|
+| `dropout_error` | `abs(achieved_dropout - target_dropout)` |
+| `gpa_error` | `abs(achieved_gpa - target_gpa)` |
+
+Targets come from the `BenchmarkProfile.reference_stats` (dropout rate and GPA mean).
+
+### Three hard constraints
+
+```python
+def constraints_func(trial):
+    return [
+        0.1 - engagement,     # engagement >= 0.1
+        lo - dropout,          # dropout >= profile lower bound
+        dropout - hi,          # dropout <= profile upper bound
+    ]
+```
+
+Constraints use Optuna's `constraints_func` on `NSGAIISampler`. Violated solutions
+are dominated regardless of objective values.
+
+### Fixed overrides
+
+`_build_fixed_overrides()` locks `config.*` and `inst.*` parameters to profile
+values. It iterates `PersonaConfig` and `InstitutionalConfig` fields, selecting
+only those where `type(val) is float` (not `isinstance`) to exclude `bool` fields
+(since `bool` is a subclass of `int` in Python).
+
+### Parallel execution model (ask/tell)
+
+When `n_workers > 1`, the calibrator uses Optuna's **ask/tell API** with
+`ProcessPoolExecutor`:
+
+```
+for each generation (batch_size = pop_size):
+    1. study.ask() * batch_size       -- get trial suggestions
+    2. trial.suggest_float()          -- sample parameter values in main process
+    3. pool.submit(worker, overrides) -- submit to process pool
+    4. as_completed()                 -- collect results as they finish
+    5. study.tell(trial, values)      -- report back in trial order
+```
+
+Key design choices:
+
+- **One pool for all generations** -- avoids repeated process spawn overhead on Windows
+- **Override dicts built in main process** -- no closures to pickle
+- **Results told in trial order** -- preserves NSGA-II generational selection semantics
+- **Failed trials marked as `FAIL`** -- untold trials get a safety `FAIL` after each batch
+- **`_WORKER_TIMEOUT_S = 300`** -- per-simulation timeout (aligned with Sobol analyzer)
+
+### Pareto front and knee point
+
+After optimization, `study.best_trials` gives the non-dominated Pareto front.
+Each trial becomes a `ParetoSolution` with achieved metrics and parameter values.
+
+**Knee point selection** (`pareto_utils.find_knee_point`):
+
+1. Sort Pareto front by `dropout_error`
+2. Min-max normalize both objectives to [0, 1]
+3. Draw a line from first to last point
+4. Find the solution with maximum perpendicular distance from this line
+5. Uses scalar cross product (avoids `np.cross` deprecation in NumPy 2.x)
+
+The knee point balances both objectives -- it is neither the best at dropout nor
+GPA, but the best compromise.
+
+### Validation of solutions
+
+`NSGAIICalibrator.validate_solution()` re-evaluates the knee point with:
+- Larger population (`n_students=500`)
+- Multiple seeds (`(42, 123, 456)` by default)
+- Returns `(dropout_mean, dropout_std, gpa_mean, gpa_std)`
+
+This runs **sequentially** -- pool overhead exceeds benefit for only 3 seeds.
+
+---
+
+## Stage 3: OULAD Validation
+
+**File:** `synthed/analysis/oulad_validator.py`
+
+Validates calibrated parameters against held-out real OULAD data.
+
+### Module split
+
+| Role | Modules |
+|------|---------|
+| Calibration (training) | BBB, FFF, DDD, EEE, AAA |
+| Validation (held-out) | CCC, GGG |
+
+### Validation metrics and tolerances
+
+| Metric | Tolerance | Type |
+|--------|-----------|------|
+| `dropout_rate` | `_DROPOUT_RATE_TOLERANCE = 0.10` | Absolute (within 10pp) |
+| `gpa_mean` | `_GPA_MEAN_TOLERANCE = 0.20` | Relative (<20%) |
+| `engagement_cv` | `_ENGAGEMENT_CV_TOLERANCE = 0.30` | Relative (<30%) |
+| `score_mean_approx` | `_SCORE_MEAN_TOLERANCE = 0.15` | Relative (<15%) |
+
+The engagement CV (coefficient of variation = std/mean) is scale-independent, making
+it comparable between OULAD click counts and SynthEd engagement scores.
+
+Score approximation: `synthed_gpa * 25.0` maps GPA 4.0 to score 100.
+
+### Grading
+
+Reports receive a letter grade based on pass rate:
+
+| Pass rate | Grade |
+|-----------|-------|
+| >= 80% | A |
+| >= 60% | B |
+| >= 40% | C |
+| < 40% | D |
+
+---
+
+## OULAD Targets Extraction
+
+**File:** `synthed/analysis/oulad_targets.py`
+
+`extract_targets()` reads real OULAD CSV files and computes `OuladTargets`:
+
+- **Dropout rate:** Fraction of students with `final_result == "Withdrawn"`
+- **Scores:** Mean, std, median from `studentAssessment.csv` (0-100 scale)
+- **GPA:** `score / 100 * _GPA_SCALE` where `_GPA_SCALE = 4.0`
+- **Engagement:** Mean daily clicks per student from `studentVle.csv` (streamed, not loaded into memory)
+- **Demographics:** Disability rate, gender distribution
+
+The `modules` parameter enables calibration/validation splits.
+
+---
+
+## auto_bounds: Adaptive Parameter Ranges
+
+**File:** `synthed/analysis/auto_bounds.py`
+
+When demographics change from defaults, the hand-tuned `SOBOL_PARAMETER_SPACE`
+bounds may no longer be appropriate. `auto_bounds()` generates bounds automatically:
+
+```python
+params = auto_bounds(config=my_config, margin=0.3)
+# bounds = default * (1 +/- 0.3), clipped to validation ranges
+```
+
+### How bounds are computed
+
+1. **Config fields:** `default * (1 +/- margin)`, clipped to `_CONFIG_RANGES` validation limits
+2. **Engine/theory constants:** Scans `_UPPERCASE` float attributes on each module. Positive
+   defaults get a floor at 10% of default value
+3. **Non-tuneable exclusions:** `_NON_TUNEABLE` frozenset lists constants that should never
+   be in sensitivity analysis (clip bounds, scale denominators, memory impact values,
+   duration/noise stds, sampling infrastructure)
+
+### Filtering
+
+- `include_config`, `include_engine`, `include_theories` flags toggle parameter groups
+- `exclude` frozenset removes specific parameter names
+- Zero-valued constants are automatically skipped (cannot compute percentage bounds)
+
+---
+
+## _sim_runner: Shared Simulation Infrastructure
+
+**File:** `synthed/analysis/_sim_runner.py`
+
+The backbone of both Sobol and NSGA-II. Every analysis simulation call goes through
+`run_simulation_with_overrides()`.
+
+### Override routing by prefix
+
+```python
+for key, value in overrides.items():
+    prefix, _, attr = key.partition(".")
+    # Route to the right target:
+    #   "config.*"  -> PersonaConfig via dataclasses.replace()
+    #   "engine.*"  -> EngineConfig via dataclasses.replace()
+    #   "inst.*"    -> InstitutionalConfig via dataclasses.replace()
+    #   "grading.*" -> GradingConfig via dataclasses.replace()
+    #   other       -> theory module via setattr()
+```
+
+| Prefix | Target | Application method |
+|--------|--------|-------------------|
+| `config` | `PersonaConfig` | `dataclasses.replace()` on frozen dataclass |
+| `engine` | `EngineConfig` | `dataclasses.replace()` on `engine.cfg` (frozen) |
+| `inst` | `InstitutionalConfig` | `dataclasses.replace()` on frozen dataclass |
+| `grading` | `GradingConfig` | `dataclasses.replace()` on frozen dataclass |
+| Theory prefixes | Module attribute | `setattr()` on mutable theory instance |
+
+`MODULE_ALIASES` maps prefix strings to engine attribute names:
+
+| Prefix | Engine attribute |
+|--------|-----------------|
+| `tinto` | `engine.tinto` |
+| `bean` | `engine.bean_metzner` |
+| `kember` | `engine.kember` |
+| `baulke` | `engine.baulke` |
+| `sdt` | `engine.sdt` |
+| `rovai` | `engine.rovai` |
+| `garrison` | `engine.garrison` |
+| `gonzalez` | `engine.gonzalez` |
+| `moore` | `engine.moore` |
+| `epstein` | `engine.epstein_axtell` |
+
+### Fresh pipeline per call
+
+Each call creates a **new `SynthEdPipeline`** instance. Instance-level attribute
+shadows do not persist across calls, ensuring full isolation for parallel execution.
+
+In `calibration_mode=True`, the pipeline sets `_calibration_mode=True` and
+`output_dir=None`, skipping CSV export and report writing. Otherwise a temporary
+directory is created and cleaned up after metrics extraction.
+
+### Grading override safety
+
+When both `pass_threshold` and `distinction_threshold` are sampled independently
+(e.g., by Sobol or NSGA-II), they may land in the wrong order. `_sim_runner`
+sorts them: `lo, hi = sorted([pass_threshold, distinction_threshold])`.
+
+---
+
+## Gotchas
+
+1. **CALIBRATION_DATA staleness** -- The piecewise linear map in `calibration.py`
+   was measured with default persona traits. Any change to engine weights, theory
+   constants, or RNG-consuming code invalidates it. The code warns in comments but
+   has no runtime staleness detection.
+
+2. **epstein is a phantom prefix** -- `MODULE_ALIASES` includes
+   `"epstein": "epstein_axtell"`, and `_sim_runner` can route overrides to it.
+   But no `SobolParameter` in `SOBOL_PARAMETER_SPACE` uses the `epstein` prefix.
+   The network module's constants are excluded from sensitivity analysis.
+
+3. **Parallel non-determinism** -- With `n_workers > 1`, simulation order is
+   non-deterministic (depends on OS scheduling). Each individual simulation is
+   still seed-deterministic, but the Pareto front may differ slightly between
+   runs due to NSGA-II's generational selection seeing results in different order.
+   Default `n_workers=1` preserves full determinism.
+
+4. **Bool/float field detection** -- `_build_fixed_overrides` uses
+   `type(val) is float` (not `isinstance`) because `bool` is a subclass of
+   `int` in Python. Using `isinstance(val, float)` would incorrectly include
+   boolean fields from `PersonaConfig`.
+
+5. **Knee point geometry** -- `find_knee_point` uses scalar cross product instead
+   of `np.cross` to avoid a NumPy 2.x deprecation warning. With <= 2 Pareto
+   solutions, it returns the first solution without geometric computation.
+
+6. **Grading threshold ordering** -- When NSGA-II or Sobol independently sample
+   `grading.pass_threshold` and `grading.distinction_threshold`, they may be
+   inverted. `_sim_runner` auto-sorts them so `pass < distinction`.
+
+7. **Timeout alignment** -- Both `SobolAnalyzer` and `NSGAIICalibrator` use
+   `_WORKER_TIMEOUT_S = 300` seconds per simulation. The Sobol analyzer's total
+   pool timeout scales with `n_total` simulations.
+
+---
+
+## Related Pages
+
+- [Pipeline Walkthrough](pipeline-walkthrough.md) -- how `CalibrationMap` is used during normal pipeline runs
+- [Dropout Mechanics](dropout-mechanics.md) -- the Baulke thresholds that calibration tunes
+- [Engagement Formula](engagement-formula.md) -- the engine weights that Sobol ranks
+- [Theory Module Reference](theory-modules.md) -- theory constants targeted by NSGA-II
+- [Data Export & OULAD](data-export.md) -- the OULAD format that validation compares against

--- a/docs/wiki/data-export.md
+++ b/docs/wiki/data-export.md
@@ -24,8 +24,8 @@ Persona attributes organized by Rovai's (2003) four factor clusters.
 | **Identity** | `student_id`, `display_id`, `name`, `age`, `gender` |
 | **Big Five** | `openness`, `conscientiousness`, `extraversion`, `agreeableness`, `neuroticism` |
 | **Cluster 1: Student Characteristics** (Tinto, Kember) | `prior_gpa`, `prior_education_level`, `years_since_last_education`, `enrolled_courses`, `goal_commitment`, `ode_beliefs`, `motivation_type`, `goal_orientation` |
-| **Cluster 2: Student Skills** (Rovai, Moore) | `digital_literacy`, `self_regulation`, `time_management`, `learner_autonomy`, `academic_reading_writing`, `has_reliable_internet`, `disability_severity`, `device_type`, `preferred_learning_style` |
-| **Cluster 3: External Factors** (Bean & Metzner) | `is_employed`, `weekly_work_hours`, `has_family_responsibilities`, `financial_stress`, `socioeconomic_level`, `perceived_cost_benefit` |
+| **Cluster 2: Student Skills** (Rovai, Moore) | `digital_literacy`, `self_regulation`, `time_management`, `learner_autonomy`, `academic_reading_writing`, `internet_reliability`, `disability_severity`, `device_type`, `preferred_learning_style` |
+| **Cluster 3: External Factors** (Bean & Metzner) | `employment_intensity`, `family_responsibility_level`, `financial_stress`, `socioeconomic_level`, `perceived_cost_benefit` |
 | **Cluster 4: Internal Factors** (Tinto, Rovai) | `academic_integration`, `social_integration`, `institutional_support_access`, `self_efficacy` |
 | **Derived** | `base_engagement_probability`, `base_dropout_risk` |
 | **LLM** | `backstory` (empty unless `--llm` flag used) |

--- a/docs/wiki/data-export.md
+++ b/docs/wiki/data-export.md
@@ -61,7 +61,7 @@ Per-student final state after simulation. Includes theory module outputs.
 | `student_id`, `display_id` | Persona identity | |
 | `has_dropped_out` | `SimulationState.has_dropped_out` | 0 or 1 |
 | `dropout_week` | `SimulationState.dropout_week` | Empty if completed |
-| `withdrawal_reason` | `SimulationState.withdrawal_reason` | `unavoidable` or empty |
+| `withdrawal_reason` | `SimulationState.withdrawal_reason` | One of 7 event codes from `UnavoidableWithdrawal._EVENT_WEIGHTS`: `serious_illness`, `family_emergency`, `forced_relocation`, `career_change`, `military_deployment`, `death`, `legal_issues`; or empty if no withdrawal |
 | `final_dropout_phase` | `SimulationState.dropout_phase` | Baulke phase 0-5 |
 | `final_engagement` | Last value in `weekly_engagement_history` | |
 | `final_gpa` | `SimulationState.cumulative_gpa` | Floor-adjusted transcript GPA |

--- a/docs/wiki/data-export.md
+++ b/docs/wiki/data-export.md
@@ -1,0 +1,392 @@
+# Data Export & OULAD
+
+SynthEd produces two export formats: a **standard 4-table** research dataset and an
+**OULAD-compatible 7-table** dataset that plugs directly into Educational Data Mining
+(EDM) pipelines built for the Open University Learning Analytics Dataset.
+
+Both exporters live in `synthed/data_output/`.
+
+---
+
+## Standard 4-Table Export
+
+**File:** `synthed/data_output/exporter.py` -- `DataExporter`
+
+Called by `pipeline.run()` via `exporter.export_all()`. Skipped when
+`_calibration_mode=True` (no `output_dir`).
+
+### students.csv
+
+Persona attributes organized by Rovai's (2003) four factor clusters.
+
+| Column group | Columns |
+|-------------|---------|
+| **Identity** | `student_id`, `display_id`, `name`, `age`, `gender` |
+| **Big Five** | `openness`, `conscientiousness`, `extraversion`, `agreeableness`, `neuroticism` |
+| **Cluster 1: Student Characteristics** (Tinto, Kember) | `prior_gpa`, `prior_education_level`, `years_since_last_education`, `enrolled_courses`, `goal_commitment`, `ode_beliefs`, `motivation_type`, `goal_orientation` |
+| **Cluster 2: Student Skills** (Rovai, Moore) | `digital_literacy`, `self_regulation`, `time_management`, `learner_autonomy`, `academic_reading_writing`, `has_reliable_internet`, `disability_severity`, `device_type`, `preferred_learning_style` |
+| **Cluster 3: External Factors** (Bean & Metzner) | `is_employed`, `weekly_work_hours`, `has_family_responsibilities`, `financial_stress`, `socioeconomic_level`, `perceived_cost_benefit` |
+| **Cluster 4: Internal Factors** (Tinto, Rovai) | `academic_integration`, `social_integration`, `institutional_support_access`, `self_efficacy` |
+| **Derived** | `base_engagement_probability`, `base_dropout_risk` |
+| **LLM** | `backstory` (empty unless `--llm` flag used) |
+
+> These are **pre-simulation** values from `StudentPersona`. For evolved/final values,
+> see `outcomes.csv`.
+
+### interactions.csv
+
+Timestamped LMS interaction logs -- one row per interaction event.
+
+| Column | Source | Notes |
+|--------|--------|-------|
+| `student_id` | `InteractionRecord.student_id` | Internal UUID |
+| `display_id` | Lookup from `StudentPersona.display_id` | Human-readable `S-0001` |
+| `week` | `InteractionRecord.week` | Simulation week (1-indexed) |
+| `course_id` | `InteractionRecord.course_id` | Course identifier |
+| `interaction_type` | `InteractionRecord.interaction_type` | `lms_login`, `forum_read`, `forum_post`, `assignment_submit`, `exam`, `live_session` |
+| `timestamp_offset_hours` | `InteractionRecord.timestamp_offset_hours` | Hours offset within the week |
+| `duration_minutes` | `InteractionRecord.duration_minutes` | Activity duration |
+| `quality_score` | `InteractionRecord.quality_score` | 0-1 scale; empty if 0 |
+| `device` | `InteractionRecord.metadata["device"]` | Device type |
+| `is_late` | `InteractionRecord.metadata["is_late"]` | Late submission flag |
+| `exam_type` | `InteractionRecord.metadata["exam_type"]` | `midterm` or `final` |
+| `post_length` | `InteractionRecord.metadata["post_length"]` | Forum post word count |
+
+### outcomes.csv
+
+Per-student final state after simulation. Includes theory module outputs.
+
+| Column | Source | Notes |
+|--------|--------|-------|
+| `student_id`, `display_id` | Persona identity | |
+| `has_dropped_out` | `SimulationState.has_dropped_out` | 0 or 1 |
+| `dropout_week` | `SimulationState.dropout_week` | Empty if completed |
+| `withdrawal_reason` | `SimulationState.withdrawal_reason` | `unavoidable` or empty |
+| `final_dropout_phase` | `SimulationState.dropout_phase` | Baulke phase 0-5 |
+| `final_engagement` | Last value in `weekly_engagement_history` | |
+| `final_gpa` | `SimulationState.cumulative_gpa` | Floor-adjusted transcript GPA |
+| `final_academic_integration` | `SimulationState.academic_integration` | Tinto |
+| `final_social_integration` | `SimulationState.social_integration` | Tinto |
+| `final_perceived_cost_benefit` | `SimulationState.perceived_cost_benefit` | Kember |
+| `courses_active_count` | `len(SimulationState.courses_active)` | |
+| `engagement_trend` | Computed | `positive`/`negative`/`stable`/`unknown` |
+| `final_social_presence` | `SimulationState.coi_state.social_presence` | Garrison CoI |
+| `final_cognitive_presence` | `SimulationState.coi_state.cognitive_presence` | Garrison CoI |
+| `final_teaching_presence` | `SimulationState.coi_state.teaching_presence` | Garrison CoI |
+| `final_motivation_type` | `SimulationState.current_motivation_type` | SDT |
+| `final_autonomy_need` | `SimulationState.sdt_needs.autonomy` | SDT |
+| `final_competence_need` | `SimulationState.sdt_needs.competence` | SDT |
+| `final_relatedness_need` | `SimulationState.sdt_needs.relatedness` | SDT |
+| `final_exhaustion_level` | `SimulationState.exhaustion.exhaustion_level` | Gonzalez |
+| `network_degree` | `SocialNetwork.get_degree()` | Epstein & Axtell |
+
+**Engagement trend** calculation: divides weekly history into quarters; if the
+mean of the last quarter exceeds the first quarter by > 0.05, trend is `positive`;
+below -0.05 is `negative`; otherwise `stable`. Requires >= 4 weeks; otherwise `unknown`.
+
+### weekly_engagement.csv
+
+Wide-format engagement trajectories.
+
+| Column | Description |
+|--------|-------------|
+| `student_id` | Internal UUID |
+| `display_id` | Human-readable ID |
+| `week_1` ... `week_N` | Engagement value (0-1) for each simulation week |
+
+`max_weeks` is computed dynamically from the longest `weekly_engagement_history`
+across all students.
+
+---
+
+## OULAD 7-Table Export
+
+**File:** `synthed/data_output/oulad_exporter.py` -- `OuladExporter`
+
+Produces CSV files matching the Open University Learning Analytics Dataset schema
+(Kuzilek et al., 2017). Output goes to `{output_dir}/oulad/`.
+
+### Table relationships
+
+```mermaid
+erDiagram
+    courses ||--o{ assessments : "code_module + code_presentation"
+    courses ||--o{ vle : "code_module + code_presentation"
+    courses ||--o{ studentInfo : "code_module + code_presentation"
+    courses ||--o{ studentRegistration : "code_module + code_presentation"
+    studentInfo ||--o{ studentAssessment : "id_student"
+    studentInfo ||--o{ studentVle : "id_student"
+    assessments ||--o{ studentAssessment : "id_assessment"
+    vle ||--o{ studentVle : "id_site"
+
+    courses {
+        string code_module
+        string code_presentation
+        int module_presentation_length
+    }
+
+    assessments {
+        string code_module
+        string code_presentation
+        int id_assessment
+        string assessment_type
+        int date
+        int weight
+    }
+
+    vle {
+        int id_site
+        string code_module
+        string code_presentation
+        string activity_type
+        int week_from
+        int week_to
+    }
+
+    studentInfo {
+        string code_module
+        string code_presentation
+        int id_student
+        string gender
+        string region
+        string highest_education
+        string imd_band
+        string age_band
+        int num_of_prev_attempts
+        int studied_credits
+        string disability
+        string final_result
+    }
+
+    studentRegistration {
+        string code_module
+        string code_presentation
+        int id_student
+        int date_registration
+        int date_unregistration
+    }
+
+    studentAssessment {
+        int id_assessment
+        int id_student
+        int date_submitted
+        int is_banked
+        int score
+    }
+
+    studentVle {
+        string code_module
+        string code_presentation
+        int id_student
+        int id_site
+        int date
+        int sum_click
+    }
+```
+
+### Catalog tables (3)
+
+#### courses.csv
+
+One row per course per presentation.
+
+| Column | Source |
+|--------|--------|
+| `code_module` | `Course.id` |
+| `code_presentation` | `semester_to_presentation(environment.semester_name)` |
+| `module_presentation_length` | `total_weeks * 7` (days) |
+
+#### assessments.csv
+
+Built by `_build_assessment_catalog()`. Creates entries for:
+
+- **TMA (tutor-marked assignments):** One per `course.assignment_weeks` entry, weight = `100 / n_assignments`
+- **Midterm as TMA:** If `midterm_week != final_week`, weight = 0
+- **Final exam:** `assessment_type = "Exam"`, weight = 100, date = empty (OULAD convention)
+
+Internal `_week` and `_type` fields are used for lookup but not exported.
+
+#### vle.csv
+
+One VLE site per interaction type per course. Activity types:
+
+| Activity type | Always present |
+|--------------|---------------|
+| `homepage` | Yes |
+| `forumng` | Yes |
+| `oucontent` | Yes |
+| `resource` | Yes |
+| `subpage` | Yes |
+| `oucollaborate` | Only if `course.has_live_sessions` |
+
+### Student profile tables (2)
+
+#### studentInfo.csv
+
+One row per (student, course) combination -- this is the OULAD convention.
+
+| Column | Mapping function | Notes |
+|--------|-----------------|-------|
+| `id_student` | `student_id_to_int(display_id)` | `"S-0001"` becomes `1` |
+| `gender` | `gender_to_oulad(gender)` | `"male"` becomes `"M"`, else `"F"` |
+| `region` | `select_region(rng)` | Weighted random from 13 UK regions |
+| `highest_education` | `education_to_oulad(prior_education_level)` | See mapping table below |
+| `imd_band` | `select_imd_band(rng, socioeconomic_level)` | SES-based band selection |
+| `age_band` | `age_to_band(age)` | `0-35`, `35-55`, or `55<=` |
+| `num_of_prev_attempts` | Hardcoded `0` | First attempt assumed |
+| `studied_credits` | `enrolled_courses * 30` | Credits estimate |
+| `disability` | `"Y"` if `disability_severity > 0` else `"N"` | |
+| `final_result` | `map_final_result(...)` | See outcome mapping below |
+
+**Education mapping** (`_EDUCATION_MAP`):
+
+| SynthEd | OULAD |
+|---------|-------|
+| `high_school` | `A Level or Equivalent` |
+| `associate` | `Lower Than A Level` |
+| `bachelor` | `HE Qualification` |
+| Other | `A Level or Equivalent` (fallback) |
+
+**Final result mapping** (`map_final_result()`):
+
+| Condition | Result |
+|-----------|--------|
+| `has_dropped_out` or `withdrawal_reason is not None` | `Withdrawn` |
+| `gpa_count == 0` (completed, no grades) | `Pass` |
+| `cumulative_gpa >= _FINAL_RESULT_DISTINCTION_GPA (3.4)` | `Distinction` |
+| `cumulative_gpa >= _FINAL_RESULT_PASS_GPA (1.6)` | `Pass` |
+| Otherwise | `Fail` |
+
+**IMD band mapping** (`_IMD_BANDS_BY_SES`):
+
+| Socioeconomic level | Possible IMD bands |
+|---------------------|-------------------|
+| `low` | `0-10%`, `10-20%`, `20-30%`, `30-40%` |
+| `middle` | `40-50%`, `50-60%`, `60-70%`, `70-80%` |
+| `high` | `80-90%`, `90-100%` |
+
+#### studentRegistration.csv
+
+| Column | Source |
+|--------|--------|
+| `date_registration` | Random integer in `[-180, -10]` (days before presentation start) |
+| `date_unregistration` | `dropout_week * 7` if dropped out, else empty |
+
+### Behavioral tables (2)
+
+#### studentAssessment.csv
+
+Graded interactions (assignments and exams) mapped via assessment catalog lookup.
+
+| Column | Source |
+|--------|--------|
+| `id_assessment` | Lookup by `(course_id, week, interaction_type)` |
+| `id_student` | `student_id_to_int(display_id)` |
+| `date_submitted` | `(week - 1) * 7 + day_offset` (days from presentation start) |
+| `is_banked` | Hardcoded `0` |
+| `score` | `round(quality_score * 100)`, clamped to `[0, 100]` |
+
+Only `assignment_submit` and `exam` interaction types are included.
+
+#### studentVle.csv
+
+Non-graded interactions mapped through VLE catalog and click heuristic.
+
+| Column | Source |
+|--------|--------|
+| `id_site` | Lookup by `(course_id, activity_type)` |
+| `id_student` | `student_id_to_int(display_id)` |
+| `date` | `(week - 1) * 7 + day_offset` |
+| `sum_click` | `click_heuristic(interaction_type, duration_minutes, metadata)` |
+
+**Interaction type to activity type mapping** (`_ACTIVITY_TYPE_MAP`):
+
+| SynthEd type | OULAD activity |
+|-------------|----------------|
+| `lms_login` | `homepage` |
+| `forum_read` | `forumng` |
+| `forum_post` | `forumng` |
+| `live_session` | `oucollaborate` |
+| `assignment_submit` | `None` (goes to studentAssessment) |
+| `exam` | `None` (goes to studentAssessment) |
+| Other | `oucontent` (fallback) |
+
+**Click heuristic** (`click_heuristic()`):
+
+| Interaction type | Formula | Minimum |
+|-----------------|---------|---------|
+| `lms_login` | 1 (constant) | 1 |
+| `forum_read` | `duration_minutes / 3` | 1 |
+| `forum_post` | `post_length / 20` | 1 |
+| `live_session` | `duration_minutes / 10` | 1 |
+| Fallback | `duration_minutes / 5` | 1 |
+
+---
+
+## Validation Data Preparation
+
+**File:** `synthed/pipeline.py` -- `SynthEdPipeline._prepare_validation_data()`
+
+Before running the 21 validation tests, the pipeline computes additional fields
+on the fly that are not stored in `SimulationState`:
+
+| Computed field | Formula | Used by |
+|---------------|---------|---------|
+| `coi_composite` | `(social_presence + cognitive_presence + teaching_presence) / 3` | Correlation validation |
+| `network_degree` | `SocialNetwork.get_degree(student_id)` | Correlation validation |
+
+These fields enable the validator to test theory-predicted correlations (e.g.,
+CoI composite vs. engagement, network degree vs. social integration) without
+requiring the engine to store redundant derived values.
+
+---
+
+## Gotchas
+
+1. **student_id vs display_id** -- Internal `student_id` is a UUID (non-deterministic,
+   embeds wall-clock time via UUIDv7). `display_id` (`S-0001`) is sequential and
+   deterministic. OULAD export converts `display_id` to integer via
+   `student_id_to_int()`. Standard export includes both.
+
+2. **Pre-simulation vs post-simulation values** -- `students.csv` contains
+   **initial** persona values (before simulation). `outcomes.csv` contains **final**
+   evolved values. Do not compare `students.csv.academic_integration` directly with
+   `outcomes.csv.final_academic_integration` -- they measure different time points.
+
+3. **One row per (student, course) in OULAD** -- `studentInfo.csv` and
+   `studentRegistration.csv` produce one row per student per course, matching
+   OULAD convention. A simulation with 200 students and 1 course produces 200 rows;
+   with 2 courses, 400 rows.
+
+4. **Region and IMD are synthetic** -- OULAD uses UK regions and IMD (Index of
+   Multiple Deprivation) bands. SynthEd generates these stochastically using
+   OULAD-observed distributions (`_REGION_WEIGHTS`). They are not derived from
+   student persona traits beyond `socioeconomic_level`.
+
+5. **Assessment weight rounding** -- TMA weights are `round(100 / n_assignments)`.
+   With 3 assignments this gives 33 per TMA (total 99, not 100). This matches
+   OULAD's real data where weights do not always sum to 100.
+
+6. **Click heuristic is lossy** -- Converting duration-based interactions to click
+   counts is inherently approximate. Forum reads at 3 minutes each become 1 click
+   per 3 minutes of reading. The heuristic was calibrated against OULAD's observed
+   click distributions but is not exact.
+
+7. **Calibration mode skips export** -- When `_calibration_mode=True`, both
+   `DataExporter` and `OuladExporter` are skipped entirely. The pipeline extracts
+   only summary metrics (`dropout_rate`, `mean_engagement`, `mean_gpa`) for the
+   calibrator. No CSV files are written.
+
+8. **Registration dates are random** -- `date_registration` is drawn uniformly from
+   `[-180, -10]` days before presentation start. This models early registration
+   behavior observed in OULAD but is not derived from any student attribute.
+
+---
+
+## Related Pages
+
+- [Pipeline Walkthrough](pipeline-walkthrough.md) -- where export fits in the pipeline stages
+- [Grading & GPA System](grading-and-gpa.md) -- how `cumulative_gpa` and `semester_grade` are computed before export
+- [Calibration & Sensitivity Analysis](calibration-and-analysis.md) -- OULAD validation that consumes exported-format data
+- [Theory Module Reference](theory-modules.md) -- theory outputs that appear in outcomes.csv
+- [Simulation Loop](simulation-loop.md) -- how interaction records are generated

--- a/docs/wiki/dropout-mechanics.md
+++ b/docs/wiki/dropout-mechanics.md
@@ -1,0 +1,329 @@
+# Dropout Mechanics
+
+SynthEd models dropout through three independent mechanisms:
+
+1. **Baulke 6-phase model** -- gradual disengagement following Baeulke et al. (2022)
+2. **Unavoidable withdrawal** -- catastrophic life events bypassing the phase model
+3. **Dropout contagion** -- peer influence accelerating disengagement (Epstein & Axtell, 1996)
+
+This page documents the exact thresholds and transition logic from the source code.
+
+---
+
+## Baulke 6-Phase Model
+
+Source: `synthed/simulation/theories/baulke.py` -- class `BaulkeDropoutPhase`
+
+The model traces a student from baseline enrollment through increasingly serious
+disengagement phases. Each phase has forward transitions (toward dropout), recovery
+transitions (back toward engagement), and specific threshold conditions.
+
+### Phase State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Phase0: Enrollment
+
+    Phase0: Phase 0 — Baseline
+    Phase1: Phase 1 — Non-Fit Perception
+    Phase2: Phase 2 — Thoughts of Quitting
+    Phase3: Phase 3 — Deliberation
+    Phase4: Phase 4 — Information Search
+    Phase5: Phase 5 — Final Decision
+
+    Phase0 --> Phase1: eng < 0.40 OR soft triggers
+    Phase1 --> Phase0: eng > 0.50
+    Phase1 --> Phase2: eng < 0.36 AND (missed >= 1 OR social < 0.20)
+    Phase2 --> Phase1: eng > 0.45
+    Phase2 --> Phase3: (eng < 0.32 AND declining history) OR severe shock
+    Phase3 --> Phase2: eng > 0.40
+    Phase3 --> Phase4: eng < 0.25 AND CB < 0.40
+    Phase4 --> Phase3: eng > 0.35 AND CB > 0.45
+    Phase4 --> Phase5: probabilistic (triggers * risk)
+    Phase5 --> [*]: Dropped out
+```
+
+### Phase 0 -> 1: Non-Fit Perception
+
+The student senses incongruence with the program. This is the first signal of disengagement.
+
+**Triggers** (any one is sufficient):
+
+| Trigger | Condition | Constants |
+|---------|-----------|-----------|
+| Low engagement | `eng < 0.40` | `_NONFIT_ENG_THRESHOLD` = 0.40 |
+| Soft: low cognitive presence | `eng < 0.45 AND coi.cognitive_presence < 0.25` | `_NONFIT_ENG_SOFT` = 0.45, `_NONFIT_COG_THRESHOLD` = 0.25 |
+| Soft: high transactional distance | `eng < 0.45 AND avg_td > 0.55` | `_NONFIT_ENG_SOFT` = 0.45, `_NONFIT_TD_THRESHOLD` = 0.55 |
+| Soft: high exhaustion | `eng < 0.45 AND exhaustion > 0.70` | `_NONFIT_ENG_SOFT` = 0.45, `_EXHAUSTION_THRESHOLD` = 0.70 |
+| Soft: low perceived mastery | `eng < 0.45 AND perceived_mastery < 0.40 AND mastery_count >= 2` | `_NONFIT_ENG_SOFT` = 0.45, `_NONFIT_MASTERY_THRESHOLD` = 0.40, `_NONFIT_GPA_MIN_ITEMS` = 2 |
+
+> **CRITICAL**: The mastery trigger uses `state.perceived_mastery` (raw quality average)
+> compared against `_NONFIT_MASTERY_THRESHOLD` (0.40). It does **NOT** use `cumulative_gpa` or
+> `_NONFIT_GPA_THRESHOLD` (1.6). The `_NONFIT_GPA_THRESHOLD` constant exists in the code but
+> is **dead code** -- no logic references it for phase transitions. See
+> [grading-and-gpa.md](grading-and-gpa.md) for the dual-track GPA explanation.
+
+### Phase 1 -> 0: Recovery
+
+| Condition | Constant |
+|-----------|----------|
+| `eng > 0.50` | `_RECOVERY_1_TO_0` = 0.50 |
+
+Recovery adds a positive memory event with impact +0.2 (`_IMPACT_RECOVERY_1_TO_0`).
+
+### Phase 1 -> 2: Thoughts of Quitting
+
+The student begins unsystematic consideration of alternatives.
+
+| Condition | Constants |
+|-----------|-----------|
+| `eng < 0.36` **AND** (`missed_assignments_streak >= 1` **OR** `social_integration < 0.20`) | `_PHASE_1_TO_2_ENG` = 0.36, `_PHASE_1_SOCIAL_THRESHOLD` = 0.20 |
+
+Both conditions must be met: low engagement **plus** at least one of the secondary triggers.
+
+### Phase 2 -> 1: Recovery
+
+| Condition | Constant |
+|-----------|----------|
+| `eng > 0.45` | `_RECOVERY_2_TO_1` = 0.45 |
+
+### Phase 2 -> 3: Deliberation
+
+The student consciously weighs pros and cons of staying vs leaving.
+
+**Two independent paths** (either is sufficient):
+
+| Path | Condition | Constants |
+|------|-----------|-----------|
+| Sustained decline | `eng < 0.32 AND len(history) >= 2 AND history[-1] < history[-2]` | `_PHASE_2_TO_3_ENG` = 0.32 |
+| Severe shock | `env_shock_remaining > 0 AND env_shock_magnitude > 0.70` | `_SHOCK_SEVERITY_THRESHOLD` = 0.70 |
+
+> **Gotcha -- declining-history guard**: The engagement path requires `history[-1] < history[-2]`,
+> meaning the most recent engagement must be **lower** than the previous week. A student stuck at
+> constant low engagement (e.g., 0.30 every week) will NOT advance to Phase 3 via this path.
+> Only a declining trend or a severe shock triggers deliberation.
+
+### Phase 3 -> 2: Recovery
+
+| Condition | Constant |
+|-----------|----------|
+| `eng > 0.40` | `_RECOVERY_3_TO_2` = 0.40 |
+
+### Phase 3 -> 4: Information Search
+
+The student actively explores alternatives to the current program.
+
+| Condition | Constants |
+|-----------|-----------|
+| `eng < 0.25 AND perceived_cost_benefit < 0.40` | `_PHASE_3_TO_4_ENG` = 0.25, `_PHASE_3_TO_4_CB` = 0.40 |
+
+Both conditions must be met. This is where Kember's cost-benefit analysis becomes gate-keeping.
+
+### Phase 4 -> 3: Recovery
+
+| Condition | Constants |
+|-----------|-----------|
+| `eng > 0.35 AND perceived_cost_benefit > 0.45` | `_RECOVERY_4_TO_3_ENG` = 0.35, `_RECOVERY_4_TO_3_CB` = 0.45 |
+
+Both conditions must be met for recovery at this late stage.
+
+### Phase 4 -> 5: Final Decision
+
+This is the only probabilistic transition. The student accumulates triggers, and the probability
+of dropout scales with the number of active triggers.
+
+**Trigger checklist:**
+
+| # | Trigger | Condition | Constant |
+|---|---------|-----------|----------|
+| 1 | Near-zero engagement | `eng < 0.10` | `_TRIGGER_ENG_THRESHOLD` = 0.10 |
+| 2 | Academic failure cascade | `missed_assignments_streak >= 3` | `_TRIGGER_MISSED_STREAK` = 3 |
+| 3 | Economic rationality | `perceived_cost_benefit < 0.15` | `_TRIGGER_CB_THRESHOLD` = 0.15 |
+| 4 | Environmental crisis | `financial_stress > 0.70` | `_TRIGGER_FINANCIAL_THRESHOLD` = 0.70 |
+| 5 | Academic exhaustion | `exhaustion > 0.70` | `_EXHAUSTION_THRESHOLD` = 0.70 |
+| 6 | Academic failure (mastery) | `perceived_mastery < 0.30 AND mastery_count >= 2` | `_TRIGGER_MASTERY_THRESHOLD` = 0.30, `_TRIGGER_GPA_MIN_ITEMS` = 2 |
+| 7 | Withdrawal deadline | `week == int(total_weeks * 0.70)` | `_WITHDRAWAL_WEEK_FRACTION` = 0.70 |
+
+**Decision probability formula:**
+
+```
+decision_prob = base_dropout_risk * triggers * _DECISION_RISK_MULTIPLIER
+```
+
+Where:
+- `base_dropout_risk` comes from `StudentPersona.base_dropout_risk` (persona-level)
+- `triggers` is the count of active triggers (1-7)
+- `_DECISION_RISK_MULTIPLIER` = 0.28
+
+If `rng.random() < decision_prob`, the student drops out.
+
+**Example**: A student with `base_dropout_risk = 0.3` and 3 active triggers:
+`0.3 * 3 * 0.28 = 0.252` -- about 25% chance of dropping out this week.
+
+---
+
+## Recovery Path Summary
+
+Every phase except Phase 5 has a recovery path. Recovery thresholds decrease as phases advance,
+reflecting the increasing difficulty of re-engagement.
+
+| Transition | Engagement Threshold | Additional Condition |
+|------------|---------------------|---------------------|
+| 1 -> 0 | > 0.50 | -- |
+| 2 -> 1 | > 0.45 | -- |
+| 3 -> 2 | > 0.40 | -- |
+| 4 -> 3 | > 0.35 | CB > 0.45 |
+
+The decreasing threshold pattern (0.50 -> 0.45 -> 0.40 -> 0.35) means recovery requires
+progressively less engagement at later phases, but by Phase 4, cost-benefit must also recover.
+
+---
+
+## Exhaustion as Accelerator
+
+Source: `synthed/simulation/theories/academic_exhaustion.py` -- class `GonzalezExhaustion`
+
+Gonzalez exhaustion interacts with Baulke at two points:
+
+1. **Phase 0 -> 1 soft trigger**: When `eng < 0.45` (soft threshold) AND `exhaustion > 0.70`
+   (`_EXHAUSTION_THRESHOLD`), the student enters Phase 1 even if engagement alone would not trigger it.
+
+2. **Phase 4 -> 5 trigger**: Exhaustion above `_DROPOUT_THRESHOLD` (0.70 in `GonzalezExhaustion`)
+   counts as one of the probabilistic triggers for the final decision.
+
+The `exhaustion_accelerates_dropout()` method returns `True` when `exhaustion_level > 0.70`.
+
+---
+
+## Unavoidable Withdrawal
+
+Source: `synthed/simulation/theories/unavoidable_withdrawal.py` -- class `UnavoidableWithdrawal`
+
+This is a separate mechanism that models catastrophic life events. It runs **before** any
+interactions are generated for a student each week and **bypasses the Baulke phase model entirely**.
+
+**Configuration:**
+- `per_semester_probability`: configured at engine initialization (default: 0.0)
+- Converted to weekly probability: `p_week = 1 - (1 - p_semester)^(1/N)`
+
+**When triggered:**
+- `state.has_dropped_out = True`
+- `state.dropout_week = week`
+- `state.withdrawal_reason` = one of the weighted event types
+- Memory entry appended with impact = -1.0
+
+**Event type distribution:**
+
+| Event | Weight |
+|-------|--------|
+| Serious illness | 0.30 |
+| Family emergency | 0.20 |
+| Forced relocation | 0.15 |
+| Career change | 0.15 |
+| Military deployment | 0.10 |
+| Death | 0.05 |
+| Legal issues | 0.05 |
+
+**Key distinction from Baulke**: Unavoidable withdrawal ignores engagement, motivation, GPA,
+and all other simulation state. It is purely stochastic with persona-independent probability.
+The `withdrawal_reason` field on `SimulationState` distinguishes these from phase-model dropouts.
+
+---
+
+## Dropout Contagion
+
+Source: `synthed/simulation/theories/epstein_axtell.py` -- class `EpsteinAxtellPeerInfluence`
+
+When a student's network neighbor drops out (or enters late dropout phases), the remaining
+student's engagement is penalized. This models the social contagion effect described in
+Epstein & Axtell (1996).
+
+The contagion operates through `SocialNetwork.dropout_contagion()`:
+- Scans the student's network neighbors
+- For each neighbor in a dropout phase (or who has dropped out), applies a penalty
+- The penalty reduces `current_engagement`, clipped to `[_ENGAGEMENT_CLIP_LO, _ENGAGEMENT_CLIP_HI]`
+
+This runs in **Phase 2** of the weekly loop, after all individual updates are complete.
+
+---
+
+## Withdrawal Deadline
+
+The constant `_WITHDRAWAL_WEEK_FRACTION` (0.70) determines the withdrawal deadline at approximately
+70% through the semester. For a 14-week semester: `int(14 * 0.70) = 9`, so week 9.
+
+At the withdrawal deadline week, an additional trigger fires for Phase 4 -> 5, reflecting
+the institutional deadline pressure described by Kember (1989).
+
+Students who drop out **after** this week may be marked differently in downstream processing
+(see [data-export.md](data-export.md) for how dropout timing affects export records).
+
+---
+
+## Memory System
+
+Each phase transition and recovery appends a memory entry to `SimulationState.memory`:
+
+```python
+{
+    "week": int,
+    "event_type": "dropout_phase" | "recovery" | "dropout" | "unavoidable_withdrawal",
+    "details": str,  # Human-readable description
+    "impact": float  # Negative for phase advances, positive for recovery
+}
+```
+
+**Impact values** (`_IMPACT_*` constants):
+
+| Transition | Impact |
+|------------|--------|
+| Phase 0 -> 1 (non-fit) | -0.2 |
+| Phase 1 -> 0 (recovery) | +0.2 |
+| Phase 1 -> 2 (thoughts) | -0.25 |
+| Phase 2 -> 1 (recovery) | +0.15 |
+| Phase 2 -> 3 (deliberation) | -0.3 |
+| Phase 3 -> 2 (recovery) | +0.1 |
+| Phase 3 -> 4 (info search) | -0.4 |
+| Phase 4 -> 5 (dropout) | -0.8 |
+| Unavoidable withdrawal | -1.0 |
+
+> **Note**: These memory entries are currently logged but **not used for decision-making**.
+> The memory system is a record-keeping facility, not a feedback mechanism.
+
+---
+
+## Gotchas
+
+- **`_NONFIT_GPA_THRESHOLD` is dead code**: The constant `_NONFIT_GPA_THRESHOLD = 1.6` exists in
+  `BaulkeDropoutPhase` but is never referenced in `advance_phase()`. Phase 0 -> 1 uses
+  `_NONFIT_MASTERY_THRESHOLD` (0.40) against `perceived_mastery`, not `cumulative_gpa`. If you
+  grep for `_NONFIT_GPA_THRESHOLD`, you will find only its definition -- no usage.
+
+- **Phase advancement happens in Phase 2**: Baulke's `advance_phase()` is called in the social
+  phase of the weekly loop (after peer influence, after engagement history is recorded). This means
+  the engagement value used for phase transitions **includes** peer contagion effects.
+
+- **One phase step per week maximum**: The code uses `elif` chains, so a student can only advance
+  or recover by one phase per week. A student cannot jump from Phase 0 to Phase 3 in a single week.
+
+- **Declining history requires >= 2 entries**: Phase 2 -> 3 via the engagement path requires
+  `len(history) >= 2 AND history[-1] < history[-2]`. In week 1, history has only 1 entry, so
+  this path is impossible. The earliest Phase 2 -> 3 via engagement can occur is week 3 (Phase 0 -> 1
+  in week 1, Phase 1 -> 2 in week 2, Phase 2 -> 3 in week 3 if history is declining).
+
+- **Operator precedence in Phase 2 -> 3**: The code reads
+  `eng < 0.32 and len(history) >= 2 and history[-1] < history[-2] or (shock...)`. Due to Python's
+  `and`/`or` precedence, this is `(eng_path) or (shock_path)` -- either the sustained-decline path
+  OR the severe-shock path triggers the transition.
+
+- **Withdrawal reason distinguishes dropout types**: `state.withdrawal_reason` is set only by
+  `UnavoidableWithdrawal`. Baulke phase-model dropouts have `withdrawal_reason = None`. Use this
+  field to distinguish the two mechanisms in exported data.
+
+- **`base_dropout_risk` is persona-level**: The risk multiplier in Phase 4 -> 5 comes from the
+  student's persona, not from simulation state. High-risk personas have structurally higher dropout
+  probability even with identical engagement trajectories.
+
+---
+
+*See also: [theory-modules.md](theory-modules.md) for all 11 modules, [simulation-loop.md](simulation-loop.md) for when Baulke fires in the weekly loop, [grading-and-gpa.md](grading-and-gpa.md) for the dual-track GPA system.*

--- a/docs/wiki/engagement-formula.md
+++ b/docs/wiki/engagement-formula.md
@@ -6,9 +6,46 @@ This page decomposes `_update_engagement()` in `synthed/simulation/engine.py` te
 
 ## Overview
 
-`_update_engagement()` is the multi-theory engagement composer. It runs once per student per week, during Phase 1, after all theory modules have updated their respective state variables. It reads state from all theory modules and computes a new `current_engagement` value.
+`_update_engagement()` is the multi-theory engagement composer. It runs once per student per week, during Phase 1, after all theory modules have updated their respective state variables. It dispatches to 9 theory implementations via `contribute_engagement_delta()` and handles 3 inline mechanics directly in the engine.
 
 The formula is additive: it starts from the current engagement, applies a series of positive and negative adjustments, then clips to [`_ENGAGEMENT_CLIP_LO` (0.01), `_ENGAGEMENT_CLIP_HI` (0.99)].
+
+---
+
+## Engagement Dispatch Architecture
+
+As of v1.6.0, the engagement composition is protocol-dispatched. Each participating theory implements:
+
+```python
+def contribute_engagement_delta(ctx: TheoryContext) -> float:
+    ...
+```
+
+The engine's `_update_engagement()` is a 27-line dispatch loop that iterates theories in `_ENGAGEMENT_ORDER` and sums their deltas. The 110-line monolith is gone — theory-specific logic lives in `theories/*.py`.
+
+### Dispatch Order Table
+
+| Theory | `_ENGAGEMENT_ORDER` | Module |
+|--------|---------------------|--------|
+| TintoIntegration | 100 | `theories/tinto.py` |
+| BeanMetzner | 200 | `theories/bean_metzner.py` |
+| PositiveEvents | 300 | `theories/positive_events.py` |
+| Rovai | 400 | `theories/rovai.py` |
+| SDT | 500 | `theories/sdt.py` |
+| Moore | 600 | `theories/moore.py` |
+| Garrison | 700 | `theories/garrison.py` |
+| Gonzalez | 800 | `theories/gonzalez.py` |
+| Kember | 900 | `theories/kember.py` |
+
+### What remains inline in the engine
+
+Three mechanics are **not** dispatched via `contribute_engagement_delta()` — they remain directly in `_update_engagement()`:
+
+- **Academic outcome bonuses/penalties** (Term 11) — per-item quality score bonuses/penalties
+- **Missed assignment streak penalty** (Term 12) — streak-compounding penalty
+- **Exam week neuroticism stress** (Term 13) — personality-modulated exam stress
+
+The **Rovai engagement floor** (Term 15) and **final clip** (Term 16) also remain in the engine as post-dispatch steps.
 
 ---
 
@@ -43,7 +80,9 @@ flowchart LR
 
 ## Term-by-Term Breakdown
 
-### Term 1: Adaptive Baseline Decay
+### Term 1: Adaptive Baseline Decay (inside Tinto's delta)
+
+> **Protocol dispatch**: `TintoIntegration.contribute_engagement_delta()` (`_ENGAGEMENT_ORDER = 100`)
 
 ```
 decay_attenuation = 1 / (1 + _DECAY_DAMPING_FACTOR * sqrt(week - 1))
@@ -60,6 +99,8 @@ decay_attenuation = 1 / (1 + _DECAY_DAMPING_FACTOR * sqrt(week - 1))
 ---
 
 ### Term 2: Tinto Integration Effect
+
+> **Protocol dispatch**: `TintoIntegration.contribute_engagement_delta()` (`_ENGAGEMENT_ORDER = 100`) — decay_attenuation is computed inside this method, not in the engine.
 
 ```
 integration_effect = academic_integration * _TINTO_ACADEMIC_WEIGHT
@@ -83,6 +124,8 @@ integration_effect = academic_integration * _TINTO_ACADEMIC_WEIGHT
 
 ### Term 3: Bean & Metzner Environmental Pressure
 
+> **Protocol dispatch**: `BeanMetzner.contribute_engagement_delta()` (`_ENGAGEMENT_ORDER = 200`) — shock state machine is now inside this method.
+
 ```
 engagement += bean_metzner.calculate_environmental_pressure(student, state.coping_factor)
 ```
@@ -102,6 +145,8 @@ Before this, `bean_metzner.update_coping(student, state)` adapts the coping fact
 ---
 
 ### Term 4: Environmental Shocks (Stochastic)
+
+> **Protocol dispatch**: Part of `BeanMetzner.contribute_engagement_delta()` (`_ENGAGEMENT_ORDER = 200`) — shock rolling and application are now handled inside this method.
 
 ```
 if env_shock_remaining > 0:
@@ -126,6 +171,8 @@ else:
 
 ### Term 5: Positive Events
 
+> **Protocol dispatch**: `PositiveEvents.contribute_engagement_delta()` (`_ENGAGEMENT_ORDER = 300`)
+
 ```
 engagement += positive_events.apply(context.get("positive_event"), student, state)
 ```
@@ -142,6 +189,8 @@ engagement += positive_events.apply(context.get("positive_event"), student, stat
 
 ### Term 6: Rovai Self-Regulation Buffer
 
+> **Protocol dispatch**: `Rovai.contribute_engagement_delta()` (`_ENGAGEMENT_ORDER = 400`)
+
 ```
 engagement += rovai.regulation_buffer(student)
 ```
@@ -157,6 +206,8 @@ engagement += rovai.regulation_buffer(student)
 ---
 
 ### Term 7: SDT Motivation Type Effect
+
+> **Protocol dispatch**: `SDT.contribute_engagement_delta()` (`_ENGAGEMENT_ORDER = 500`)
 
 ```
 motivation_effect = {
@@ -180,6 +231,8 @@ motivation_effect = {
 
 ### Term 8: Moore Transactional Distance Effect
 
+> **Protocol dispatch**: `Moore.contribute_engagement_delta()` (`_ENGAGEMENT_ORDER = 600`)
+
 ```
 avg_td = moore.average(student, state, self.env)
 td_effect = -(avg_td - 0.5) * _TD_EFFECT_FACTOR
@@ -197,6 +250,8 @@ td_effect = -(avg_td - 0.5) * _TD_EFFECT_FACTOR
 ---
 
 ### Term 9: Garrison CoI Effect
+
+> **Protocol dispatch**: `Garrison.contribute_engagement_delta()` (`_ENGAGEMENT_ORDER = 700`)
 
 ```
 coi_effect = social_presence * _COI_SOCIAL_WEIGHT
@@ -222,6 +277,8 @@ coi_effect = social_presence * _COI_SOCIAL_WEIGHT
 ---
 
 ### Term 10: Gonzalez Exhaustion Drag
+
+> **Protocol dispatch**: `Gonzalez.contribute_engagement_delta()` (`_ENGAGEMENT_ORDER = 800`)
 
 ```
 engagement += gonzalez.exhaustion_engagement_effect(state)
@@ -295,6 +352,8 @@ if is_exam_week:
 ---
 
 ### Term 14: Kember Cost-Benefit Recalculation and Feedback
+
+> **Protocol dispatch**: `Kember.contribute_engagement_delta()` (`_ENGAGEMENT_ORDER = 900`) — conditional recalculation logic is now inside this method.
 
 ```
 # Triggered when: is_exam_week OR missed_streak >= 2 OR has graded item this week
@@ -440,6 +499,7 @@ The terms with the **smallest impact** are:
 - **`scale_by()` at default InstitutionalConfig is a no-op** — with all parameters at 0.5, every `scale_by()` call returns the original constant. You only see institutional effects when you change `InstitutionalConfig`.
 - **Academic outcome terms apply per-item, not per-course** — if a student submits 4 assignments in one week (rare, but possible with overlapping `assignment_weeks`), each one independently triggers a bonus or penalty.
 - **Environmental shock magnitude is multiplied by 0.05** — the raw magnitude from `bean_metzner.stochastic_pressure_event()` is much larger than the actual engagement impact. Do not confuse the stored `env_shock_magnitude` with the per-week engagement penalty.
+- **Engagement composition is protocol-dispatched** — `_update_engagement()` is a 27-line dispatch loop, not a 110-line monolith. It calls `contribute_engagement_delta(ctx: TheoryContext) -> float` on each theory in `_ENGAGEMENT_ORDER` order and sums the results. Theory-specific logic lives in `theories/*.py`, not in the engine.
 
 ---
 

--- a/docs/wiki/engagement-formula.md
+++ b/docs/wiki/engagement-formula.md
@@ -136,9 +136,10 @@ Before this, `bean_metzner.update_coping(student, state)` adapts the coping fact
 |----------|--------|---------|
 | `coping_factor` | `SimulationState` | 0.0, grows over time (max 0.5) |
 | `financial_stress` | `StudentPersona` | Varies |
-| `is_employed` | `StudentPersona` | Varies |
+| `employment_intensity` | `StudentPersona` | [0,1] continuous |
+| `family_responsibility_level` | `StudentPersona` | [0,1] continuous |
 
-**What it does:** Environmental pressure from employment, financial stress, and family obligations erodes engagement. Coping develops over time and attenuates the pressure. Employed students with high financial stress feel the largest penalty.
+**What it does:** Environmental pressure from employment intensity, financial stress, and family obligations erodes engagement. Coping develops over time and attenuates the pressure. Higher employment intensity and financial stress produce the largest penalty.
 
 **Typical magnitude:** Ranges from ~0 (low-stress, adapted student) to approximately **-0.04** (high-stress employed student early in semester).
 

--- a/docs/wiki/engagement-formula.md
+++ b/docs/wiki/engagement-formula.md
@@ -127,7 +127,7 @@ else:
 ### Term 5: Positive Events
 
 ```
-engagement += positive_events.apply(context["positive_event"], student, state)
+engagement += positive_events.apply(context.get("positive_event"), student, state)
 ```
 
 | Variable | Source |
@@ -163,7 +163,7 @@ motivation_effect = {
     "intrinsic":  +_MOTIVATION_INTRINSIC_BOOST,
     "extrinsic":   0.0,
     "amotivation": -_MOTIVATION_AMOTIVATION_PENALTY,
-}[current_motivation_type]
+}.get(current_motivation_type, 0.0)
 ```
 
 | Variable | Source | Default |

--- a/docs/wiki/engagement-formula.md
+++ b/docs/wiki/engagement-formula.md
@@ -1,0 +1,446 @@
+# Engagement Update Formula
+
+This page decomposes `_update_engagement()` in `synthed/simulation/engine.py` term by term. For the overall simulation flow, see [Simulation Loop](simulation-loop.md). For which theory modules update state before this formula runs, see [Theory Module Reference](theory-modules.md).
+
+---
+
+## Overview
+
+`_update_engagement()` is the multi-theory engagement composer. It runs once per student per week, during Phase 1, after all theory modules have updated their respective state variables. It reads state from all theory modules and computes a new `current_engagement` value.
+
+The formula is additive: it starts from the current engagement, applies a series of positive and negative adjustments, then clips to [`_ENGAGEMENT_CLIP_LO` (0.01), `_ENGAGEMENT_CLIP_HI` (0.99)].
+
+---
+
+## Engagement Waterfall Diagram
+
+The diagram below shows the additive/subtractive contributions of each term for a typical student at week 7. Signs indicate direction of effect; actual magnitudes depend on student state.
+
+```mermaid
+flowchart LR
+    E0["Current<br/>Engagement"] --> T1
+    T1["+/- Tinto<br/>Integration"] --> T2
+    T2["- Bean & Metzner<br/>Env. Pressure"] --> T3
+    T3["-/0 Env. Shock<br/>(stochastic)"] --> T4
+    T4["+/0 Positive<br/>Event"] --> T5
+    T5["+ Rovai<br/>Regulation Buffer"] --> T6
+    T6["+/- SDT<br/>Motivation Type"] --> T7
+    T7["+/- Moore<br/>TD Effect"] --> T8
+    T8["+/- Garrison<br/>CoI Effect"] --> T9
+    T9["- Gonzalez<br/>Exhaustion Drag"] --> T10
+    T10["+/- Academic<br/>Outcome Bonus"] --> T11
+    T11["-/0 Missed Assign.<br/>Streak Penalty"] --> T12
+    T12["-/0 Exam Week<br/>Neuro. Stress"] --> T13
+    T13["+/- Kember<br/>Cost-Benefit"] --> T14
+    T14["max(Rovai Floor)"] --> T15
+    T15["clip to<br/>[0.01, 0.99]"]
+
+    style E0 fill:#e3f2fd
+    style T15 fill:#e8f5e9
+```
+
+---
+
+## Term-by-Term Breakdown
+
+### Term 1: Adaptive Baseline Decay
+
+```
+decay_attenuation = 1 / (1 + _DECAY_DAMPING_FACTOR * sqrt(week - 1))
+```
+
+| Variable | Source | Default |
+|----------|--------|---------|
+| `_DECAY_DAMPING_FACTOR` | `EngineConfig` | 0.5 |
+
+**What it does:** The decay attenuation factor decreases over time, making the Tinto decay term (Term 2) weaker in later weeks. At week 1: `1.0`. At week 7: `1 / (1 + 0.5 * sqrt(6))` = ~0.55. At week 14: `1 / (1 + 0.5 * sqrt(13))` = ~0.36.
+
+**Magnitude:** This is a multiplier on the Tinto decay, not a direct engagement change.
+
+---
+
+### Term 2: Tinto Integration Effect
+
+```
+integration_effect = academic_integration * _TINTO_ACADEMIC_WEIGHT
+                   + social_integration * _TINTO_SOCIAL_WEIGHT
+                   - _TINTO_DECAY_BASE * decay_attenuation
+```
+
+| Variable | Source | Default |
+|----------|--------|---------|
+| `_TINTO_ACADEMIC_WEIGHT` | `EngineConfig` | 0.06 |
+| `_TINTO_SOCIAL_WEIGHT` | `EngineConfig` | 0.02 |
+| `_TINTO_DECAY_BASE` | `EngineConfig` | 0.05 |
+| `academic_integration` | `SimulationState` | Evolves via `tinto.update_integration()` |
+| `social_integration` | `SimulationState` | Evolves via `tinto.update_integration()` |
+
+**What it does:** Higher academic and social integration boost engagement, while a baseline decay pulls it down. The decay weakens over time via `decay_attenuation`.
+
+**Typical magnitude:** With both integrations at 0.5 and week 7 decay: `0.5 * 0.06 + 0.5 * 0.02 - 0.05 * 0.55` = `0.03 + 0.01 - 0.0275` = **+0.0125**. This term is near-zero or slightly positive for average students; strongly positive for well-integrated students.
+
+---
+
+### Term 3: Bean & Metzner Environmental Pressure
+
+```
+engagement += bean_metzner.calculate_environmental_pressure(student, state.coping_factor)
+```
+
+Before this, `bean_metzner.update_coping(student, state)` adapts the coping factor.
+
+| Variable | Source | Default |
+|----------|--------|---------|
+| `coping_factor` | `SimulationState` | 0.0, grows over time (max 0.5) |
+| `financial_stress` | `StudentPersona` | Varies |
+| `is_employed` | `StudentPersona` | Varies |
+
+**What it does:** Environmental pressure from employment, financial stress, and family obligations erodes engagement. Coping develops over time and attenuates the pressure. Employed students with high financial stress feel the largest penalty.
+
+**Typical magnitude:** Ranges from ~0 (low-stress, adapted student) to approximately **-0.04** (high-stress employed student early in semester).
+
+---
+
+### Term 4: Environmental Shocks (Stochastic)
+
+```
+if env_shock_remaining > 0:
+    engagement -= env_shock_magnitude * 0.05
+    # decrement remaining weeks
+else:
+    # roll for new shock via bean_metzner.stochastic_pressure_event()
+    if triggered:
+        engagement -= magnitude * 0.05
+```
+
+| Variable | Source |
+|----------|--------|
+| `env_shock_remaining` | `SimulationState` |
+| `env_shock_magnitude` | `SimulationState` |
+
+**What it does:** Acute life events (medical emergency, family crisis) cause a multi-week engagement penalty. Magnitude and duration are stochastic, drawn from the Bean & Metzner module.
+
+**Typical magnitude:** When active, **-0.01 to -0.05** per week depending on shock severity. Most weeks: 0 (no active shock).
+
+---
+
+### Term 5: Positive Events
+
+```
+engagement += positive_events.apply(context["positive_event"], student, state)
+```
+
+| Variable | Source |
+|----------|--------|
+| `positive_event` | `ODLEnvironment.positive_events` dict (week-keyed) |
+
+**What it does:** Counter-pressure from positive environmental events (orientation welcome, financial aid disbursement, semester break, peer study group). Only fires on specific weeks defined in `ODLEnvironment`.
+
+**Typical magnitude:** **+0.01 to +0.03** on event weeks; 0 on other weeks.
+
+---
+
+### Term 6: Rovai Self-Regulation Buffer
+
+```
+engagement += rovai.regulation_buffer(student)
+```
+
+| Variable | Source |
+|----------|--------|
+| `self_regulation` | `StudentPersona` |
+
+**What it does:** Students with higher self-regulation get a small weekly engagement buffer. This models Rovai's persistence factor — self-regulated students are more consistent.
+
+**Typical magnitude:** **+0.005 to +0.02** depending on `self_regulation` score.
+
+---
+
+### Term 7: SDT Motivation Type Effect
+
+```
+motivation_effect = {
+    "intrinsic":  +_MOTIVATION_INTRINSIC_BOOST,
+    "extrinsic":   0.0,
+    "amotivation": -_MOTIVATION_AMOTIVATION_PENALTY,
+}[current_motivation_type]
+```
+
+| Variable | Source | Default |
+|----------|--------|---------|
+| `_MOTIVATION_INTRINSIC_BOOST` | `EngineConfig` | 0.02 |
+| `_MOTIVATION_AMOTIVATION_PENALTY` | `EngineConfig` | 0.025 |
+| `current_motivation_type` | `SimulationState` | Shifts via `sdt.evaluate_motivation_shift()` |
+
+**What it does:** Intrinsically motivated students get a weekly boost; amotivated students get a penalty; extrinsic is neutral. Motivation type can shift across weeks based on SDT need satisfaction.
+
+**Typical magnitude:** **+0.02** (intrinsic), **0** (extrinsic), **-0.025** (amotivation). Fixed per-week effect.
+
+---
+
+### Term 8: Moore Transactional Distance Effect
+
+```
+avg_td = moore.average(student, state, self.env)
+td_effect = -(avg_td - 0.5) * _TD_EFFECT_FACTOR
+```
+
+| Variable | Source | Default |
+|----------|--------|---------|
+| `_TD_EFFECT_FACTOR` | `EngineConfig` | 0.03 |
+| `avg_td` | Computed from `Course` fields + `student.learner_autonomy` | Varies |
+
+**What it does:** Higher transactional distance (high structure, low dialogue, low autonomy) penalizes engagement. The effect is centered at 0.5 — courses with balanced TD have no effect.
+
+**Typical magnitude:** **-0.015 to +0.015**. The range is `0.03 * 0.5` = 0.015 in either direction from neutral.
+
+---
+
+### Term 9: Garrison CoI Effect
+
+```
+coi_effect = social_presence * _COI_SOCIAL_WEIGHT
+           + cognitive_presence * _COI_COGNITIVE_WEIGHT
+           + teaching_presence * _COI_TEACHING_WEIGHT
+           - _COI_BASELINE_OFFSET
+```
+
+| Variable | Source | Default |
+|----------|--------|---------|
+| `_COI_SOCIAL_WEIGHT` | `EngineConfig` | 0.01 |
+| `_COI_COGNITIVE_WEIGHT` | `EngineConfig` | 0.02 |
+| `_COI_TEACHING_WEIGHT` | `EngineConfig` | 0.01 |
+| `_COI_BASELINE_OFFSET` | `EngineConfig` | 0.02 |
+| `social_presence` | `CommunityOfInquiryState` | Initial 0.3 |
+| `cognitive_presence` | `CommunityOfInquiryState` | Initial 0.4 |
+| `teaching_presence` | `CommunityOfInquiryState` | Initial 0.5 (from `inst.teaching_presence_baseline`) |
+
+**What it does:** The three presences contribute positively, offset by a baseline. When all presences are at their initial values: `0.3 * 0.01 + 0.4 * 0.02 + 0.5 * 0.01 - 0.02` = `0.003 + 0.008 + 0.005 - 0.02` = **-0.004**. The offset ensures CoI must be built up through interaction to provide positive engagement effects.
+
+**Typical magnitude:** **-0.005 to +0.01** depending on presence levels.
+
+---
+
+### Term 10: Gonzalez Exhaustion Drag
+
+```
+engagement += gonzalez.exhaustion_engagement_effect(state)
+```
+
+| Variable | Source |
+|----------|--------|
+| `exhaustion.exhaustion_level` | `ExhaustionState` |
+
+**What it does:** Higher exhaustion drags engagement down. The effect is computed by the Gonzalez module based on `exhaustion_level`.
+
+**Typical magnitude:** **-0.03 to 0** depending on exhaustion level. Heavily loaded students late in the semester feel this most.
+
+---
+
+### Term 11: Academic Outcome Bonuses/Penalties
+
+```
+for each assignment_submit or exam record this week:
+    if quality_score > _HIGH_QUALITY_THRESHOLD:  engagement += _HIGH_QUALITY_BOOST
+    if quality_score < _LOW_QUALITY_THRESHOLD:    engagement -= _LOW_QUALITY_PENALTY
+```
+
+| Variable | Source | Default |
+|----------|--------|---------|
+| `_HIGH_QUALITY_THRESHOLD` | `EngineConfig` | 0.7 |
+| `_HIGH_QUALITY_BOOST` | `EngineConfig` | 0.025 |
+| `_LOW_QUALITY_THRESHOLD` | `EngineConfig` | 0.3 |
+| `_LOW_QUALITY_PENALTY` | `EngineConfig` | 0.035 |
+
+**What it does:** Good performance this week boosts engagement; poor performance penalizes it. Each graded item applies independently.
+
+**Typical magnitude:** **+0.025** per high-quality item, **-0.035** per low-quality item. On exam weeks with 4 courses, a strong student might get 4 * 0.025 = **+0.10** — a significant swing.
+
+---
+
+### Term 12: Missed Assignment Streak Penalty
+
+```
+if missed_assignments_streak >= 2:
+    engagement -= _MISSED_STREAK_PENALTY * min(streak - 1, _MISSED_STREAK_CAP)
+```
+
+| Variable | Source | Default |
+|----------|--------|---------|
+| `_MISSED_STREAK_PENALTY` | `EngineConfig` | 0.04 |
+| `_MISSED_STREAK_CAP` | `EngineConfig` | 3 |
+
+**What it does:** Consecutive missed assignments compound the penalty. Streak of 2: `0.04 * 1` = **-0.04**. Streak of 3: `0.04 * 2` = **-0.08**. Streak of 4+: `0.04 * 3` = **-0.12** (capped).
+
+**Typical magnitude:** 0 for most students; **-0.04 to -0.12** for students who stop submitting.
+
+---
+
+### Term 13: Exam Week Neuroticism Stress
+
+```
+if is_exam_week:
+    engagement -= neuroticism * _NEUROTICISM_EXAM_FACTOR
+```
+
+| Variable | Source | Default |
+|----------|--------|---------|
+| `_NEUROTICISM_EXAM_FACTOR` | `EngineConfig` | 0.04 |
+| `neuroticism` | `StudentPersona.personality` | Varies (0-1) |
+
+**What it does:** High-neuroticism students suffer an engagement penalty during exam weeks (midterm and final). Low-neuroticism students barely feel it.
+
+**Typical magnitude:** **-0.02** (average neuroticism) to **-0.04** (high neuroticism) during exam weeks; 0 otherwise.
+
+---
+
+### Term 14: Kember Cost-Benefit Recalculation and Feedback
+
+```
+# Triggered when: is_exam_week OR missed_streak >= 2 OR has graded item this week
+kember.recalculate(student, state, context, records, avg_td, ...)
+engagement += (perceived_cost_benefit - 0.5) * _CB_FEEDBACK_FACTOR
+```
+
+| Variable | Source | Default |
+|----------|--------|---------|
+| `_CB_FEEDBACK_FACTOR` | `EngineConfig` | 0.02 |
+| `perceived_cost_benefit` | `SimulationState` | Initial from persona, evolves via Kember |
+
+**What it does:** After major events (exams, missed assignments, any graded item), Kember's cost-benefit perception is recalculated. The updated perception feeds back into engagement. Students who perceive the cost outweighing benefits (`perceived_cost_benefit < 0.5`) get a penalty; the opposite get a boost.
+
+**Typical magnitude:** **-0.01 to +0.01**. This is a small but persistent effect that accumulates over time. The real impact of Kember is through its influence on `perceived_cost_benefit`, which is read by [Dropout Mechanics](dropout-mechanics.md).
+
+---
+
+### Term 15: Rovai Engagement Floor
+
+```
+engagement = max(engagement, rovai.engagement_floor(student))
+```
+
+**What it does:** Sets a persona-dependent lower bound on engagement. High self-regulation and goal commitment students have a higher floor, preventing their engagement from collapsing completely.
+
+---
+
+### Term 16: Final Clip
+
+```
+state.current_engagement = clip(engagement, _ENGAGEMENT_CLIP_LO, _ENGAGEMENT_CLIP_HI)
+```
+
+| Variable | Source | Default |
+|----------|--------|---------|
+| `_ENGAGEMENT_CLIP_LO` | `EngineConfig` | 0.01 |
+| `_ENGAGEMENT_CLIP_HI` | `EngineConfig` | 0.99 |
+
+**What it does:** Hard bounds prevent engagement from reaching exactly 0 or 1.
+
+---
+
+## `InstitutionalConfig` and `scale_by()`
+
+Several terms above are modulated by `InstitutionalConfig` via `scale_by()`:
+
+```python
+scale_by(constant, inst_param) = constant * (0.7 + 0.6 * inst_param)
+```
+
+At `inst_param = 0.5` (default), `scale_by` returns `constant * 1.0` — no effect.
+At `inst_param = 0.0`, returns `constant * 0.7` — 30% reduction.
+At `inst_param = 1.0`, returns `constant * 1.3` — 30% increase.
+
+**Which terms are affected:**
+
+| Term | InstitutionalConfig Parameter | What is scaled |
+|------|-------------------------------|----------------|
+| LMS login floor | `technology_quality` | `_LOGIN_LITERACY_FLOOR` |
+| Forum read floor | `technology_quality` | `_FORUM_READ_LITERACY_FLOOR` |
+| Assignment quality | `instructional_design_quality` | `_ASSIGN_GPA_WEIGHT`, `_ASSIGN_ENG_WEIGHT` |
+| Exam quality | `instructional_design_quality` | `_EXAM_GPA_WEIGHT`, `_EXAM_ENG_WEIGHT` |
+| Gonzalez exhaustion | `support_services_quality`, `curriculum_flexibility` | Recovery and load weights |
+| Kember recalculation | `instructional_design_quality` | Quality factor in cost-benefit |
+| CoI teaching_presence | `teaching_presence_baseline` | Initial value (direct, not via `scale_by`) |
+
+---
+
+## Example Scenarios
+
+### Scenario A: High-Risk Employed Student at Week 7
+
+Student profile: employed, high financial stress (0.8), low self-regulation (0.3), extrinsic motivation, neuroticism 0.7.
+
+| Term | Contribution | Notes |
+|------|-------------|-------|
+| Tinto integration | +0.005 | Low academic (0.3) and social (0.2) integration |
+| Bean & Metzner | -0.035 | High environmental pressure, partial coping |
+| Env. shock | 0 | No active shock this week |
+| Positive event | 0 | Week 7 is midterm, no positive event scheduled |
+| Rovai buffer | +0.005 | Low self-regulation |
+| SDT motivation | 0 | Extrinsic = neutral |
+| Moore TD | -0.008 | Slightly high transactional distance |
+| Garrison CoI | -0.004 | Presences near initial values |
+| Gonzalez exhaustion | -0.015 | Moderate exhaustion from workload |
+| Academic outcomes | -0.035 | One low-quality midterm exam |
+| Missed streak | -0.04 | Streak of 2 missed assignments |
+| Exam stress | -0.028 | Neuroticism 0.7 * 0.04 |
+| Kember feedback | -0.006 | Cost-benefit at 0.2 |
+| **Net delta** | **-0.161** | **Substantial drop** |
+
+Starting from engagement 0.40, this student would drop to ~0.24 — putting them on a fast track through Baulke phases.
+
+### Scenario B: Motivated Self-Regulated Student at Week 7
+
+Student profile: not employed, low financial stress (0.2), high self-regulation (0.8), intrinsic motivation, neuroticism 0.3.
+
+| Term | Contribution | Notes |
+|------|-------------|-------|
+| Tinto integration | +0.04 | High academic (0.7) and social (0.5) integration |
+| Bean & Metzner | -0.005 | Low environmental pressure |
+| Env. shock | 0 | No active shock |
+| Positive event | 0 | No event this week |
+| Rovai buffer | +0.015 | High self-regulation |
+| SDT motivation | +0.02 | Intrinsic boost |
+| Moore TD | +0.005 | Balanced transactional distance |
+| Garrison CoI | +0.005 | Above-average presences |
+| Gonzalez exhaustion | -0.005 | Low exhaustion |
+| Academic outcomes | +0.05 | Two high-quality midterms |
+| Missed streak | 0 | No missed assignments |
+| Exam stress | -0.012 | Low neuroticism |
+| Kember feedback | +0.008 | Cost-benefit at 0.9 |
+| **Net delta** | **+0.121** | **Strong boost** |
+
+Starting from engagement 0.65, this student would rise to ~0.77 — well above dropout risk.
+
+---
+
+## Relative Contribution Analysis
+
+Under typical conditions, the terms with the **largest impact** are:
+
+1. **Academic outcome bonuses/penalties** (Term 11) — can swing +0.10 or -0.14 on multi-exam weeks
+2. **Missed assignment streak** (Term 12) — up to -0.12 for chronic non-submitters
+3. **Bean & Metzner environmental pressure** (Term 3) — persistent drag for at-risk students
+4. **Tinto integration effect** (Term 2) — the main positive driver for well-integrated students
+5. **SDT motivation type** (Term 7) — stable +0.02 or -0.025 per week accumulates significantly
+
+The terms with the **smallest impact** are:
+
+1. **Kember cost-benefit feedback** (Term 14) — tiny direct effect, but influences dropout via `perceived_cost_benefit`
+2. **Garrison CoI effect** (Term 9) — small deltas, builds slowly
+3. **Moore TD effect** (Term 8) — narrow range around neutral
+
+---
+
+## Gotchas
+
+- **Engagement is NOT momentum-based** — there is no `engagement += delta` term that carries velocity. Each week recomputes from the current value plus additive adjustments. A student can go from 0.3 to 0.6 in a single good week.
+- **Kember recalculation is conditional** — it only fires when there is an exam week, a missed streak >= 2, or a graded item this week. On quiet weeks with no assignments or exams, cost-benefit stays unchanged.
+- **The Rovai floor is checked BEFORE the final clip** — a student's engagement floor from Rovai can be higher than `_ENGAGEMENT_CLIP_LO` (0.01), providing a persona-dependent safety net.
+- **`scale_by()` at default InstitutionalConfig is a no-op** — with all parameters at 0.5, every `scale_by()` call returns the original constant. You only see institutional effects when you change `InstitutionalConfig`.
+- **Academic outcome terms apply per-item, not per-course** — if a student submits 4 assignments in one week (rare, but possible with overlapping `assignment_weeks`), each one independently triggers a bonus or penalty.
+- **Environmental shock magnitude is multiplied by 0.05** — the raw magnitude from `bean_metzner.stochastic_pressure_event()` is much larger than the actual engagement impact. Do not confuse the stored `env_shock_magnitude` with the per-week engagement penalty.
+
+---
+
+*See also: [Pipeline Walkthrough](pipeline-walkthrough.md) for where the engine fits in the pipeline, [Simulation Loop](simulation-loop.md) for the weekly execution order, [Theory Module Reference](theory-modules.md) for all 11 modules, [Grading & GPA](grading-and-gpa.md) for how `_record_graded_item` feeds quality scores, [Calibration & Analysis](calibration-and-analysis.md) for Sobol sensitivity of engagement weights, [Data Export](data-export.md) for how engagement history is exported.*

--- a/docs/wiki/grading-and-gpa.md
+++ b/docs/wiki/grading-and-gpa.md
@@ -1,0 +1,351 @@
+# Grading & GPA System
+
+SynthEd uses a dual-track GPA system that is the most common source of confusion in the codebase.
+This page explains the two tracks, the grading pipeline, and outcome classification.
+
+> **Key insight**: A student with low raw quality still gets a non-zero transcript GPA (grade floor),
+> but theory modules see the true low quality via `perceived_mastery`. These two numbers diverge
+> and serve different purposes.
+
+---
+
+## Dual-Track GPA
+
+Source: `synthed/simulation/engine.py` -- `SimulationState` dataclass and `_record_graded_item()` method
+
+Every time a graded item (assignment or exam) is recorded, two parallel tracks are updated:
+
+### Track 1: `cumulative_gpa` (Transcript GPA)
+
+The grade the student sees on their transcript. A structural **grade floor** is applied before
+scaling to 4.0.
+
+**Formula** (in `_record_graded_item()`):
+
+```
+graded = grade_floor + (1 - grade_floor) * quality
+gpa_points_sum += graded * _GPA_SCALE
+gpa_count += 1
+cumulative_gpa = gpa_points_sum / gpa_count
+```
+
+Where:
+- `quality` is raw [0-1] score from the interaction
+- `grade_floor` = 0.45 (default, from `GradingConfig.grade_floor`)
+- `_GPA_SCALE` = 4.0 (from `EngineConfig._GPA_SCALE`)
+
+**Example**: A student submits an assignment with raw quality = 0.30:
+- `graded = 0.45 + (1 - 0.45) * 0.30 = 0.45 + 0.165 = 0.615`
+- GPA contribution: `0.615 * 4.0 = 2.46`
+
+Even a zero-quality submission gets `0.45 * 4.0 = 1.80` on the GPA scale.
+
+### Track 2: `perceived_mastery` (Raw Quality)
+
+What the student actually understands -- no floor, no inflation.
+
+**Formula** (in `_record_graded_item()`):
+
+```
+perceived_mastery_sum += quality
+perceived_mastery_count += 1
+perceived_mastery = perceived_mastery_sum / perceived_mastery_count
+```
+
+Returns 0.5 when no items have been recorded (see the `@property` on `SimulationState`).
+
+**Example** (same student): `perceived_mastery = 0.30` -- the raw truth.
+
+### Why Two Tracks?
+
+| Track | Used By | Purpose |
+|-------|---------|---------|
+| `cumulative_gpa` | Outcome classification, data export, assignment/exam quality formulas | Reflects institutional grading policy (floor, scale) |
+| `perceived_mastery` | Baulke dropout (Phase 0->1, Phase 4->5), Kember cost-benefit, SDT competence | Theory modules need the unvarnished signal |
+
+The separation prevents the grade floor from masking genuine academic struggle. A student with
+`cumulative_gpa = 2.46` (looks OK) might have `perceived_mastery = 0.30` (actually struggling),
+and theory modules correctly detect the struggle.
+
+### Numeric Example: Divergence Over Time
+
+| Week | Raw Quality | cumulative_gpa | perceived_mastery |
+|------|------------|----------------|-------------------|
+| 2 (assignment) | 0.30 | 2.46 | 0.30 |
+| 4 (assignment) | 0.25 | 2.36 | 0.275 |
+| 7 (midterm exam) | 0.20 | 2.25 | 0.25 |
+| 10 (assignment) | 0.35 | 2.31 | 0.275 |
+
+The GPA hovers around 2.3 (passing range) while mastery stays below 0.30 (non-fit territory
+for Baulke's `_NONFIT_MASTERY_THRESHOLD` = 0.40).
+
+---
+
+## GradingConfig
+
+Source: `synthed/simulation/grading.py` -- frozen dataclass
+
+`GradingConfig` is a frozen dataclass that defines institution-level grading policy.
+Override via `dataclasses.replace()`.
+
+### Assessment Modes
+
+| Mode | Behavior |
+|------|----------|
+| `"mixed"` (default) | Midterm components + final exam, weighted by `midterm_weight` / `final_weight` |
+| `"exam_only"` | `semester_grade = final_score` only. Note: `cumulative_gpa` still includes all graded items |
+| `"continuous"` | All weight on midterm components, no final needed |
+
+### Key Fields
+
+| Field | Default | Purpose |
+|-------|---------|---------|
+| `scale` | `GradingScale.SCALE_100` | Output scale (100-point or 4.0) |
+| `assessment_mode` | `"mixed"` | See above |
+| `midterm_weight` | 0.40 | Weight of midterm aggregate |
+| `final_weight` | 0.60 | Weight of final exam |
+| `midterm_components` | `{"exam": 0.50, "assignment": 0.30, "forum": 0.20}` | Component weights (must sum to 1.0) |
+| `grading_method` | `"absolute"` | `"absolute"` or `"relative"` |
+| `grade_floor` | 0.45 | Structural grade floor |
+| `pass_threshold` | 0.64 | Minimum for Pass (on floor-adjusted scale) |
+| `distinction_threshold` | 0.73 | Minimum for Distinction (on floor-adjusted scale) |
+| `dual_hurdle` | `False` | Both midterm and final must independently pass |
+| `component_pass_thresholds` | `{}` | Per-component thresholds for dual hurdle |
+| `exam_eligibility_threshold` | `None` | Midterm score required to sit the final exam |
+| `late_penalty` | 0.05 | Late submission penalty |
+| `noise_std` | 0.05 | Measurement noise (not used by engine) |
+| `missing_policy` | `"zero"` | `"zero"` or `"redistribute"` for missing components |
+| `distribution` | `"beta"` | Grade distribution type (not used by engine) |
+| `dist_alpha` / `dist_beta` | 5.0 / 3.0 | Distribution parameters (not used by engine) |
+
+**Validation** (in `__post_init__`):
+- `midterm_weight + final_weight` must sum to 1.0
+- `midterm_components` values must sum to 1.0
+- `distinction_threshold > pass_threshold`
+- All numeric fields in valid ranges
+
+---
+
+## Semester Grade Calculation
+
+Source: `synthed/simulation/grading.py` -- `calculate_semester_grade()`
+
+Called at end-of-run by `_assign_outcomes()` via `_filter_eligible_states()`.
+
+**For `"mixed"` mode:**
+
+```
+midterm_aggregate = sum(component_mean * component_weight for each component)
+semester_grade = midterm_aggregate * midterm_weight + final_score * final_weight
+```
+
+Where `component_mean = sum(scores) / n_total` (uses correct denominator -- submitted 2/4 = sum/4).
+
+**For `"exam_only"` mode:** `semester_grade = final_score`
+
+**For `"continuous"` mode:** `semester_grade = midterm_aggregate * midterm_weight` (no final needed)
+
+> **Important**: `semester_grade` on `SimulationState` is raw [0-1], NOT floor-adjusted.
+> The floor is applied during outcome classification, not during grade calculation.
+
+---
+
+## Outcome Classification Flow
+
+Source: `synthed/simulation/engine.py` -- `_assign_outcomes()` and related methods
+
+```mermaid
+flowchart TD
+    A[Student] --> B{has_dropped_out?}
+    B -->|Yes| C[Outcome: Withdrawn]
+    B -->|No| D{gpa_count == 0?}
+    D -->|Yes| E[Outcome: Fail]
+    D -->|No| F{exam_eligibility_threshold set?}
+    F -->|Yes| G{adjusted_midterm >= threshold?}
+    G -->|No| H[Outcome: Fail]
+    G -->|Yes| I[Calculate semester_grade]
+    F -->|No| I
+    I --> J{semester_grade is None?}
+    J -->|Yes| K[Outcome: Fail]
+    J -->|No| L{grading_method?}
+    L -->|absolute| M[Absolute Classification]
+    L -->|relative| N[Relative Classification]
+
+    M --> O[adjusted = floor + 1-floor x raw]
+    O --> P{dual_hurdle?}
+    P -->|Yes, fails| Q[Outcome: Fail]
+    P -->|No or passes| R{adjusted >= distinction_threshold?}
+    R -->|Yes| S[Outcome: Distinction]
+    R -->|No| T{adjusted >= pass_threshold?}
+    T -->|Yes| U[Outcome: Pass]
+    T -->|No| V[Outcome: Fail]
+
+    N --> W{eligible < 2 OR zero variance?}
+    W -->|Yes| M
+    W -->|No| X[t_scores = apply_relative_grading]
+    X --> Y[normalized = normalize_t_scores]
+    Y --> Z[Classify with dual_hurdle check]
+```
+
+### Step-by-Step
+
+1. **Dropped out?** -> "Withdrawn"
+2. **No graded items?** (`gpa_count == 0`) -> "Fail"
+3. **Exam eligibility check** (optional): if `exam_eligibility_threshold` is set, the floor-adjusted
+   midterm aggregate must meet it, otherwise -> "Fail"
+4. **Calculate `semester_grade`**: raw [0-1] via `calculate_semester_grade()`
+5. **Dispatch** to absolute or relative grading
+
+### Absolute Grading
+
+Source: `_assign_outcomes_absolute()` and `_classify_absolute_single()`
+
+1. Floor-adjust the grade: `adjusted = floor + (1 - floor) * raw`
+2. Check dual hurdle (if enabled): both midterm and final must independently pass
+3. Classify: `adjusted >= distinction_threshold` -> Distinction, `>= pass_threshold` -> Pass, else Fail
+
+**Example** (defaults: floor=0.45, pass=0.64, distinction=0.73):
+- Raw quality = 0.50: `adjusted = 0.45 + 0.55 * 0.50 = 0.725` -> Pass (0.725 >= 0.64 but < 0.73)
+- Raw quality = 0.55: `adjusted = 0.45 + 0.55 * 0.55 = 0.7525` -> Distinction (>= 0.73)
+- Raw quality = 0.30: `adjusted = 0.45 + 0.55 * 0.30 = 0.615` -> Fail (< 0.64)
+
+### Relative Grading
+
+Source: `_assign_outcomes_relative()`
+
+1. Collect raw `semester_grade` for all eligible (non-dropped, non-zero-grade) students
+2. **Fallback check**: if fewer than 2 eligible students OR zero variance -> fall back to absolute
+3. Apply t-score standardization: `T = 50 + 10 * (X - mean) / std`
+   - Population std (ddof=0) -- the cohort IS the population
+   - Warns if n < 30 (`_MIN_T_SCORE_N`)
+4. Normalize t-scores to [0-1]: `normalized = t_score / 100`
+5. Classify using the same thresholds + dual hurdle check
+
+**Fallback conditions** (in `_assign_outcomes_relative()`):
+- `len(eligible) < 2` -> absolute fallback with warning
+- All t-scores equal 50.0 (zero variance) -> absolute fallback with warning
+
+### Dual Hurdle
+
+Source: `grading.py` -- `check_dual_hurdle_pass()`
+
+When `GradingConfig.dual_hurdle = True`, both midterm and final must independently meet their
+thresholds in `component_pass_thresholds`.
+
+```python
+# Example configuration
+GradingConfig(
+    dual_hurdle=True,
+    component_pass_thresholds={"midterm": 0.40, "final": 0.40},
+)
+```
+
+A student who aces the final but fails the midterm component will get "Fail" regardless of
+their overall grade.
+
+---
+
+## Piecewise-Linear GPA Conversion
+
+Source: `synthed/simulation/grading.py` -- `piecewise_gpa()` and `_GPA_BREAKPOINTS`
+
+When `GradingScale.SCALE_4` is used, raw [0-1] quality is converted to 0-4.0 GPA
+using piecewise-linear interpolation between these breakpoints:
+
+| Quality (0-1) | GPA (0-4.0) |
+|---------------|-------------|
+| 0.00 | 0.0 |
+| 0.40 | 1.0 |
+| 0.55 | 2.0 |
+| 0.70 | 3.0 |
+| 0.85 | 3.7 |
+| 1.00 | 4.0 |
+
+These breakpoints are OULAD/WES-grounded. Between breakpoints, linear interpolation applies.
+
+**Example**: quality = 0.62 falls between (0.55, 2.0) and (0.70, 3.0):
+- `frac = (0.62 - 0.55) / (0.70 - 0.55) = 0.467`
+- `GPA = 2.0 + 0.467 * 1.0 = 2.467`
+
+---
+
+## Functions Not Used by Engine
+
+Two functions in `grading.py` exist but are NOT called by `SimulationEngine`:
+
+| Function | Purpose | Why Not Used |
+|----------|---------|--------------|
+| `compute_grade()` | Apply floor + noise + scale conversion | Engine applies floor in `_record_graded_item` and `_assign_outcomes` separately |
+| `sample_base_quality()` | Sample from grade distribution | Engine computes quality from persona traits directly |
+
+These are available for external use, Sobol analysis, and future versions.
+
+---
+
+## How the Engine Records Grades
+
+Source: `engine.py` -- `_record_graded_item()`, `_sim_assignment()`, `_sim_exam()`
+
+The engine records grades in two places per graded interaction:
+
+1. **`_record_graded_item(state, quality)`**: Updates both GPA tracks (cumulative_gpa and perceived_mastery)
+2. **Score lists**: Appends to `state.assignment_scores`, `state.midterm_exam_scores`, or `state.final_score`
+
+The score lists hold raw [0-1] quality values. The floor adjustment happens only at classification time.
+
+**Assignment quality formula** (simplified):
+
+```
+quality = (gpa_weight * gpa_normalized
+         + eng_weight * engagement
+         + efficacy_weight * self_efficacy
+         + reading_weight * reading_hours_normalized
+         + noise_weight * noise)
+```
+
+Weights from `EngineConfig`: `_ASSIGN_GPA_WEIGHT` (0.25) + `_ASSIGN_ENG_WEIGHT` (0.25) +
+`_ASSIGN_EFFICACY_WEIGHT` (0.20) + `_ASSIGN_READING_WEIGHT` (0.15) + `_ASSIGN_NOISE_WEIGHT` (0.15) = 1.0.
+
+**Exam quality formula** uses similar structure with different weights (see `EngineConfig`).
+
+---
+
+## Gotchas
+
+- **`semester_grade` is raw, NOT floor-adjusted**: The `semester_grade` field on `SimulationState`
+  stores the raw [0-1] weighted average. The floor is applied only during outcome classification
+  in `_classify_absolute_single()`. Do not compare `semester_grade` directly against
+  `pass_threshold` -- the threshold is on the floor-adjusted scale.
+
+- **`cumulative_gpa` includes ALL graded items in `exam_only` mode**: Even though `semester_grade`
+  uses only `final_score`, the running `cumulative_gpa` accumulates midterm exam and assignment
+  scores too. This affects assignment/exam quality formulas that use `cumulative_gpa` as input.
+
+- **Thresholds are on the transcript scale**: `pass_threshold` (0.64) and `distinction_threshold`
+  (0.73) are compared against `floor + (1-floor) * raw`, not against raw quality. With the default
+  floor of 0.45, a raw quality of ~0.345 maps to 0.64 (pass) and ~0.509 maps to 0.73 (distinction).
+
+- **Grade floor inflates ALL grades**: Even a zero-quality item gets `floor * GPA_SCALE = 1.80`
+  on the 4.0 scale. This is intentional -- it models partial credit and baseline marks from
+  assignment templates.
+
+- **Relative grading falls back silently**: If the cohort has fewer than 2 eligible students or
+  zero variance in grades, relative grading silently falls back to absolute with a log warning.
+  This can happen in small simulations or when most students drop out.
+
+- **`perceived_mastery` returns 0.5 with no items**: The `@property` returns 0.5 (neutral) when
+  `perceived_mastery_count == 0`. This means theory modules see a neutral signal early in the
+  semester, not zero. The `_NONFIT_GPA_MIN_ITEMS = 2` guard in Baulke prevents premature
+  non-fit detection.
+
+- **Component weight validation**: `midterm_components` must sum to 1.0 and only accept keys
+  `{"exam", "assignment", "forum"}` (enforced in `GradingConfig.__post_init__`). The assignment
+  and exam quality weight sums are also validated in `EngineConfig.__post_init__`.
+
+- **`compute_grade()` and `sample_base_quality()` are NOT used by the engine**: These exist for
+  external consumers. If you modify them, engine behavior is unaffected. If you need to change
+  how the engine grades, modify `_record_graded_item()` and `_assign_outcomes()`.
+
+---
+
+*See also: [Pipeline Walkthrough](pipeline-walkthrough.md) for where grading fits in the pipeline, [Simulation Loop](simulation-loop.md) for the end-of-run outcome assignment, [Theory Module Reference](theory-modules.md) for which modules read perceived_mastery vs cumulative_gpa, [Dropout Mechanics](dropout-mechanics.md) for how mastery triggers dropout phases, [Engagement Formula](engagement-formula.md) for academic outcome bonuses/penalties, [Data Export](data-export.md) for how GPA and outcomes appear in CSV files.*

--- a/docs/wiki/grading-and-gpa.md
+++ b/docs/wiki/grading-and-gpa.md
@@ -329,8 +329,8 @@ Weights from `EngineConfig`: `_ASSIGN_GPA_WEIGHT` (0.25) + `_ASSIGN_ENG_WEIGHT` 
   on the 4.0 scale. This is intentional -- it models partial credit and baseline marks from
   assignment templates.
 
-- **Relative grading falls back silently**: If the cohort has fewer than 2 eligible students or
-  zero variance in grades, relative grading silently falls back to absolute with a log warning.
+- **Relative grading falls back automatically**: If the cohort has fewer than 2 eligible students or
+  zero variance in grades, relative grading automatically falls back to absolute with a log warning.
   This can happen in small simulations or when most students drop out.
 
 - **`perceived_mastery` returns 0.5 with no items**: The `@property` returns 0.5 (neutral) when

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -1,0 +1,81 @@
+# SynthEd Developer Wiki
+
+SynthEd is a Python agent-based simulation for generating synthetic Open & Distance Learning (ODL) data, grounded in 11 educational and sociological theories.
+
+This wiki documents the **internals** — what happens under the hood when you run the simulation, which theory modules affect which state variables, and what non-obvious behaviors to watch out for.
+
+- **User-facing configuration** (CLI flags, JSON config, troubleshooting): see [GUIDE.md](../GUIDE.md)
+- **Academic foundations** (theory citations, factor clusters, validation suite inventory): see [THEORY.md](../THEORY.md)
+- **Quick start and project overview**: see [README.md](../../README.md)
+
+---
+
+## Reading Order
+
+If you are new to the codebase, read these pages in order:
+
+1. [Pipeline Walkthrough](pipeline-walkthrough.md) — what happens when you run `python run_pipeline.py`
+2. [The Weekly Simulation Loop](simulation-loop.md) — Phase 1 (individual) and Phase 2 (social) mechanics
+3. [Engagement Update Formula](engagement-formula.md) — the multi-theory engagement composer, term by term
+4. [Theory Module Reference](theory-modules.md) — all 11 modules: what they read, write, and when they fire
+5. [Dropout Mechanics](dropout-mechanics.md) — Baulke 6-phase model, unavoidable withdrawal, contagion
+6. [Grading & GPA System](grading-and-gpa.md) — dual-track GPA, outcome classification, relative grading
+7. [Calibration & Sensitivity Analysis](calibration-and-analysis.md) — Sobol, NSGA-II, CalibrationMap
+8. [Data Export & OULAD](data-export.md) — 4-table standard export, 7-table OULAD export
+
+---
+
+## "I Want to Understand..."
+
+| Question | Page |
+|----------|------|
+| What happens when I run `python run_pipeline.py --n 500`? | [Pipeline Walkthrough](pipeline-walkthrough.md) |
+| How does the simulation decide what a student does each week? | [Simulation Loop](simulation-loop.md) |
+| Why did this student's engagement drop at week 7? | [Engagement Formula](engagement-formula.md) |
+| Which theory module writes `social_integration`? | [Theory Module Reference](theory-modules.md) |
+| How does a student go from "enrolled" to "dropped out"? | [Dropout Mechanics](dropout-mechanics.md) |
+| Why does `cumulative_gpa` differ from `perceived_mastery`? | [Grading & GPA](grading-and-gpa.md) |
+| What is `CalibrationMap` and when do I re-measure it? | [Calibration & Analysis](calibration-and-analysis.md) |
+| How does `--target-dropout 0.40 0.60` work? | [Pipeline Walkthrough](pipeline-walkthrough.md) + [Calibration & Analysis](calibration-and-analysis.md) |
+| What columns are in the exported CSV files? | [Data Export & OULAD](data-export.md) |
+| How does the OULAD 7-table format differ from standard export? | [Data Export & OULAD](data-export.md) |
+| What is `scale_by()` and how does `InstitutionalConfig` work? | [Theory Module Reference](theory-modules.md) + [Engagement Formula](engagement-formula.md) |
+| How do multi-semester simulations carry over state? | [Simulation Loop](simulation-loop.md) |
+
+---
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| `StudentPersona` | Immutable frozen dataclass representing a student's traits, demographics, and personality. Never mutated during simulation. Located in `synthed/agents/persona.py`. |
+| `SimulationState` | Mutable dataclass tracking a student's evolving state (engagement, GPA, dropout phase, etc.) during simulation. Located in `synthed/simulation/engine.py`. |
+| `EngineConfig` | Frozen dataclass holding all 70+ simulation engine constants (weights, thresholds, clip bounds). Override via `dataclasses.replace()`. Located in `synthed/simulation/engine_config.py`. |
+| `ODLEnvironment` | Dataclass representing the semester structure: courses, weeks, scheduled events, positive events. Located in `synthed/simulation/environment.py`. |
+| `Course` | Dataclass for a single course, including Moore transactional distance fields (`structure_level`, `dialogue_frequency`, `instructor_responsiveness`). Located in `synthed/simulation/environment.py`. |
+| `PersonaConfig` | Frozen dataclass controlling population generation distributions (age ranges, employment rates, trait means). Located in `synthed/agents/persona.py`. |
+| `InstitutionalConfig` | Frozen dataclass with 5 float parameters [0,1] representing institution-level quality. `scale_by()` modulates engine constants. Located in `synthed/simulation/institutional.py`. |
+| `GradingConfig` | Frozen dataclass controlling assessment modes, component weights, pass/distinction thresholds, and grade floor. Located in `synthed/simulation/grading.py`. |
+| `SynthEdPipeline` | End-to-end orchestrator: configure, generate, simulate, export, validate, report. Located in `synthed/pipeline.py`. |
+| `SimulationEngine` | The core simulation engine running the two-phase weekly loop across all students. Located in `synthed/simulation/engine.py`. |
+| `CalibrationMap` | Piecewise linear interpolation mapping target dropout rates to `dropout_base_rate` values. Located in `synthed/calibration.py`. |
+| `InteractionRecord` | Dataclass for a single student interaction event (login, forum post, assignment, exam). Located in `synthed/simulation/engine.py`. |
+| `CommunityOfInquiryState` | Per-student CoI state tracking social, cognitive, and teaching presence (Garrison et al., 2000). Located in `synthed/simulation/engine.py`. |
+| `SDTNeedSatisfaction` | Per-student Self-Determination Theory needs: autonomy, competence, relatedness (Deci & Ryan, 1985). Located in `synthed/simulation/theories/sdt_motivation.py`. |
+| `ExhaustionState` | Per-student exhaustion tracking (Gonzalez et al., 2025): `exhaustion_level` and `recovery_capacity`. Located in `synthed/simulation/theories/academic_exhaustion.py`. |
+| `SocialNetwork` | Peer network with link formation, decay, and degree tracking (Epstein & Axtell, 1996). Located in `synthed/simulation/social_network.py`. |
+| `MultiSemesterRunner` | Orchestrates sequential semester simulations with inter-semester carry-over. Only used when `n_semesters >= 2`. Located in `synthed/simulation/semester.py`. |
+| `scale_by()` | Modulation function: `constant * (0.7 + 0.6 * inst_param)`. At `inst_param=0.5`, returns `constant` exactly. Located in `synthed/simulation/institutional.py`. |
+| Dual-track GPA | `cumulative_gpa` (transcript, grade floor applied) vs. `perceived_mastery` (raw quality, no floor). Theory modules use `perceived_mastery` for dropout signals. |
+| Baulke phases | 6-phase dropout progression: 0 (Baseline) through 5 (Final Decision = dropout). See [Dropout Mechanics](dropout-mechanics.md). |
+
+---
+
+## Gotchas
+
+- **Do not mutate `StudentPersona`** — it is a frozen dataclass. Use `dataclasses.replace()` for any modifications (e.g., multi-semester carry-over).
+- **`SimulationState.semester_grade` is raw [0,1]**, NOT floor-adjusted. The floor is applied during outcome classification in `_assign_outcomes`.
+- **RNG determinism depends on interaction order** — the 5 interaction generators fire in a fixed order (logins, forum, assignment, live, exam) per course. Changing this order changes all downstream random draws.
+- **`CALIBRATION_DATA` was measured with DEFAULT persona traits** — if you change `PersonaConfig` defaults or engine weights, the calibration data may be stale. Re-measure with `run_calibration.py`.
+- **Student IDs are non-deterministic** — UUIDv7 embeds wall-clock time, so IDs change across runs even with the same seed.
+- **File size rule** — all files (code and docs) should stay under 800 lines. Split if approaching.

--- a/docs/wiki/pipeline-walkthrough.md
+++ b/docs/wiki/pipeline-walkthrough.md
@@ -1,0 +1,252 @@
+# Pipeline Walkthrough
+
+This page traces the full execution path from `python run_pipeline.py` through every pipeline stage to the final report. For CLI flags and configuration options, see [GUIDE.md](../GUIDE.md).
+
+---
+
+## Entry Points
+
+SynthEd has two entry points:
+
+1. **CLI** — `run_pipeline.py` parses arguments, creates a `SynthEdPipeline`, and calls `pipeline.run()`
+2. **Python API** — instantiate `SynthEdPipeline` directly and call `.run()`
+
+```python
+from synthed.pipeline import SynthEdPipeline
+pipeline = SynthEdPipeline(output_dir="./output", seed=42)
+report = pipeline.run(n_students=200)
+```
+
+---
+
+## Pipeline Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant CLI as run_pipeline.py
+    participant P as SynthEdPipeline
+    participant F as StudentFactory
+    participant E as SimulationEngine
+    participant X as DataExporter
+    participant O as OuladExporter
+    participant V as SyntheticDataValidator
+
+    CLI->>P: __init__(persona_config, environment, ...)
+    Note over P: If target_dropout_range set:<br/>CalibrationMap.estimate_from_range()
+    CLI->>P: run(n_students=200)
+    
+    P->>P: _check_cost_before_enrichment() [if LLM enabled]
+    
+    P->>F: generate_population(n=200)
+    F-->>P: List[StudentPersona]
+    
+    alt n_semesters == 1
+        P->>E: engine.run(students)
+        E-->>P: records, states, network
+    else n_semesters >= 2
+        P->>E: MultiSemesterRunner.run(students)
+        E-->>P: records, states, network
+    end
+    
+    alt not _calibration_mode
+        P->>X: export_all(students, records, states, network)
+        X-->>P: file_paths
+        opt export_oulad enabled
+            P->>O: export_all(students, records, states, environment)
+            O-->>P: oulad_paths
+        end
+    end
+    
+    P->>P: _prepare_validation_data(students, states, network)
+    P->>V: validate_all(students_data, outcomes_data, weekly_eng)
+    V-->>P: validation_report
+    
+    P->>P: Write pipeline_report.json
+    P-->>CLI: report dict
+```
+
+---
+
+## Pipeline Decision Flowchart
+
+```mermaid
+flowchart TD
+    START[run_pipeline.py] --> BENCH{--benchmark?}
+    BENCH -->|Yes| BG[BenchmarkGenerator]
+    BG --> BPROFILE{--benchmark-profile?}
+    BPROFILE -->|Yes| SINGLE_BENCH[Run single profile]
+    BPROFILE -->|No| ALL_BENCH[Run all profiles + report]
+    SINGLE_BENCH --> DONE[Exit]
+    ALL_BENCH --> DONE
+    
+    BENCH -->|No| CONFIG{--config?}
+    CONFIG -->|Yes| LOAD_JSON[Load JSON config]
+    CONFIG -->|No| DEFAULTS[Use CLI args + defaults]
+    LOAD_JSON --> PIPELINE
+    DEFAULTS --> PIPELINE
+    
+    PIPELINE[SynthEdPipeline.__init__] --> CAL{target_dropout_range?}
+    CAL -->|Yes| CALMAP[CalibrationMap.estimate_from_range]
+    CALMAP --> CALSET[Set dropout_base_rate on PersonaConfig]
+    CALSET --> RUN
+    CAL -->|No| RUN
+    
+    RUN[pipeline.run] --> COST{LLM enabled?}
+    COST -->|Yes| CHECK[_check_cost_before_enrichment]
+    CHECK --> GEN
+    COST -->|No| GEN
+    
+    GEN["[1/4] factory.generate_population"] --> SIM_BRANCH{n_semesters >= 2?}
+    SIM_BRANCH -->|Yes| MULTI["[2/4] MultiSemesterRunner.run"]
+    SIM_BRANCH -->|No| SINGLE["[2/4] engine.run"]
+    MULTI --> EXPORT_CHECK
+    SINGLE --> EXPORT_CHECK
+    
+    EXPORT_CHECK{_calibration_mode?}
+    EXPORT_CHECK -->|Yes| VALIDATE
+    EXPORT_CHECK -->|No| EXPORT["[3/4] exporter.export_all"]
+    EXPORT --> OULAD{export_oulad?}
+    OULAD -->|Yes| OULAD_EX[OuladExporter.export_all]
+    OULAD_EX --> VALIDATE
+    OULAD -->|No| VALIDATE
+    
+    VALIDATE["[4/4] validator.validate_all"] --> REPORT[Write pipeline_report.json]
+```
+
+---
+
+## `SynthEdPipeline.__init__()` — What Gets Created
+
+When you instantiate the pipeline, these components are created:
+
+| Component | Class | Purpose |
+|-----------|-------|---------|
+| `self.factory` | `StudentFactory` | Population generation from `PersonaConfig` distributions |
+| `self.engine` | `SimulationEngine` | Week-by-week simulation with all theory modules |
+| `self.exporter` | `DataExporter` | CSV export (4 standard tables) |
+| `self.validator` | `SyntheticDataValidator` | Statistical validation against `ReferenceStatistics` |
+| `self.llm` | `LLMClient` or `None` | Optional LLM for persona backstory enrichment |
+
+If `target_dropout_range` is provided, `_apply_calibration()` runs immediately during `__init__()`:
+
+1. `CalibrationMap().estimate_from_range(target_range, n_semesters)` computes an estimated `dropout_base_rate`
+2. `PersonaConfig` is replaced (immutably) with the calibrated `dropout_base_rate`
+3. `ReferenceStatistics` is updated with the target range midpoint for validation
+
+---
+
+## `pipeline.run()` — Stage by Stage
+
+### Stage 1: Cost Check (conditional)
+
+When LLM enrichment is enabled (`use_llm=True`), `_check_cost_before_enrichment(n_students)` runs first:
+
+- Estimates cost via `LLMClient.estimate_cost(n_calls=n_students)`
+- If cost exceeds `cost_threshold` (default `_DEFAULT_COST_THRESHOLD_USD` = 1.0 USD), prompts the user via `confirm_callback`
+- In library mode (no callback), blocks by default to prevent surprise charges
+
+### Stage 2: Population Generation
+
+`factory.generate_population(n=n_students, enrich_with_llm=enrich)` creates the student population:
+
+- Each student is a frozen `StudentPersona` dataclass
+- Traits are sampled from distributions defined in `PersonaConfig`
+- Optional LLM enrichment adds narrative backstories
+
+### Stage 3: Simulation
+
+The branching point: single vs. multi-semester.
+
+**Single semester** (`n_semesters <= 1`, the default):
+```python
+records, states, network = self.engine.run(students)
+```
+
+**Multi-semester** (`n_semesters >= 2`):
+```python
+runner = MultiSemesterRunner(self.engine, self.n_semesters, ...)
+result = runner.run(students)
+records, states, network = result.all_records, result.final_states, result.final_network
+```
+
+`MultiSemesterRunner` loops through semesters sequentially:
+1. Run `engine.run()` with current active students
+2. Tag records with semester metadata, offset week numbers
+3. Filter out permanently dropped students (Baulke phase >= 5 or unavoidable withdrawal)
+4. Apply carry-over adjustments to surviving students (see [Simulation Loop](simulation-loop.md))
+5. Feed adjusted state into next semester
+
+### Stage 4: Export (skipped in calibration mode)
+
+When `_calibration_mode=True` (used internally by NSGA-II), export is skipped entirely to save I/O.
+
+**Standard export** — `DataExporter.export_all()` writes 4 CSV files. See [Data Export](data-export.md).
+
+**OULAD export** (optional, `--oulad` flag) — `OuladExporter.export_all()` writes 7 additional CSV tables in OULAD-compatible format.
+
+### Stage 5: Validation
+
+`_prepare_validation_data()` computes derived fields needed by the validator:
+- CoI composite: average of social, cognitive, and teaching presence
+- Network degree from `SocialNetwork`
+- Four factor clusters (student characteristics, skills, external factors, internal factors)
+
+`validator.validate_all()` runs the statistical test suite and returns a structured report.
+
+### Stage 6: Report
+
+The full report is written to `pipeline_report.json` in the output directory. Includes timing breakdowns, population summary, simulation summary, validation results, and optional LLM costs.
+
+---
+
+## CalibrationMap: Target Dropout Mapping
+
+`CalibrationMap` uses piecewise linear interpolation to convert a target dropout rate into a `dropout_base_rate` parameter.
+
+**How it works:**
+
+1. `CALIBRATION_DATA` in `synthed/calibration.py` contains empirically measured points (N=500, 5 seeds averaged per point)
+2. Each point maps a `dropout_base_rate` to an `observed_dropout_rate` for a given `n_semesters`
+3. `np.interp()` interpolates between these points
+4. Result is clamped to [`_MIN_BASE_RATE` (0.10), `_MAX_BASE_RATE` (0.95)]
+
+**Example:**
+
+Target range `(0.40, 0.60)` with 1 semester:
+1. Midpoint = 0.50, tolerance = 0.10
+2. Looking up observed rates in `CALIBRATION_DATA` for 1 semester:
+   - `dropout_base_rate=0.40` -> `observed=0.390`
+   - `dropout_base_rate=0.50` -> `observed=0.442`
+   - `dropout_base_rate=0.60` -> `observed=0.468`
+   - `dropout_base_rate=0.70` -> `observed=0.512`
+3. Interpolating for target 0.50: estimated `dropout_base_rate` falls between 0.60 and 0.70
+4. Confidence: "high" (within interpolated range) or "low" (clamped/edge)
+
+**Confidence levels:**
+- `"high"` — target is within the calibrated range and data exists for the requested `n_semesters`
+- `"low"` — target is outside the calibrated range, OR semester fallback was used (no data for requested `n_semesters`, fell back to 1-semester data)
+
+---
+
+## The `_calibration_mode` Flag
+
+When `_calibration_mode=True`:
+- Export is skipped (no CSV files written)
+- `output_dir` can be `None`
+- Report is not written to disk
+- This is used by `_sim_runner.py` inside the NSGA-II calibrator to run fast simulation-only passes
+
+---
+
+## Gotchas
+
+- **CalibrationMap is NOT a live optimizer** — it is a static lookup table measured at a specific point in time. If you change engine weights, theory modules, or RNG-consuming code paths (even non-dropout features), the calibration data becomes stale. Re-measure using `run_calibration.py`.
+- **`_apply_calibration()` mutates `PersonaConfig` and `ReferenceStatistics`** — via `dataclasses.replace()` (immutable replacement), so the original objects are not affected, but the pipeline's internal references change.
+- **Multi-semester `n_semesters=1`** — `MultiSemesterRunner` requires `n_semesters >= 2`. The pipeline routes `n_semesters <= 1` directly to `engine.run()`.
+- **LLM cost check happens before generation** — if you set `use_llm=True` but enrichment is blocked by the cost check, students are still generated (without LLM backstories).
+- **Validation always runs** — even in `_calibration_mode`, the validator is called. Only export is skipped.
+- **`from_profile()` class method** — creates a pipeline from a named benchmark profile, using the profile's `expected_dropout_range` as the `target_dropout_range` for calibration.
+
+---
+
+*See also: [Simulation Loop](simulation-loop.md) for the weekly engine loop, [Engagement Formula](engagement-formula.md) for the multi-theory composer, [Theory Module Reference](theory-modules.md) for all 11 modules, [Dropout Mechanics](dropout-mechanics.md) for the Baulke phase model, [Grading & GPA](grading-and-gpa.md) for outcome classification, [Calibration & Analysis](calibration-and-analysis.md) for CalibrationMap internals, [Data Export](data-export.md) for CSV output formats.*

--- a/docs/wiki/pipeline-walkthrough.md
+++ b/docs/wiki/pipeline-walkthrough.md
@@ -13,7 +13,7 @@ SynthEd has two entry points:
 
 ```python
 from synthed.pipeline import SynthEdPipeline
-pipeline = SynthEdPipeline(output_dir="./output", seed=42)
+pipeline = SynthEdPipeline(output_dir="./output", seed=42)  # All parameters are optional
 report = pipeline.run(n_students=200)
 ```
 

--- a/docs/wiki/simulation-loop.md
+++ b/docs/wiki/simulation-loop.md
@@ -1,0 +1,276 @@
+# The Weekly Simulation Loop
+
+This page documents the two-phase weekly simulation loop at the core of SynthEd. For how individual theory modules work, see [Theory Module Reference](theory-modules.md). For the engagement update formula specifically, see [Engagement Formula](engagement-formula.md).
+
+---
+
+## Overview
+
+`SimulationEngine.run()` in `synthed/simulation/engine.py` runs a two-phase weekly loop inspired by Epstein & Axtell (1996):
+
+- **Phase 1 (Individual):** Each non-dropped student acts independently — interactions, theory updates, engagement update
+- **Phase 2 (Social):** Network formation, peer influence, engagement recording, dropout phase advancement
+
+This separation ensures that one student's interactions in a given week do not affect another student's interactions in that same week (Phase 1 isolation), while peer effects are applied uniformly after all individuals have acted (Phase 2).
+
+---
+
+## Weekly Loop Flowchart
+
+```mermaid
+flowchart TD
+    subgraph INIT["Initialization (before week 1)"]
+        A1[Create SimulationState per student<br/>from StudentPersona fields]
+        A2[Apply initial_state_overrides<br/>if multi-semester carry-over]
+        A3[Create or reuse SocialNetwork]
+        A1 --> A2 --> A3
+    end
+
+    INIT --> WEEK_START
+
+    WEEK_START["For week = 1 to total_weeks"]
+    WEEK_START --> CTX["env.get_week_context(week)"]
+    CTX --> P1
+
+    subgraph P1["Phase 1: Individual Behavior"]
+        direction TB
+        P1_LOOP["For each student (not dropped out)"]
+        P1_LOOP --> UW{"UnavoidableWithdrawal<br/>.check_withdrawal()?"}
+        UW -->|Yes: withdrawn| P1_SKIP[Skip to next student]
+        UW -->|No| INTERACT["_simulate_student_week()<br/>5 interaction generators"]
+        INTERACT --> TINTO["tinto.update_integration()"]
+        TINTO --> GARRISON["garrison.update_presences()"]
+        GARRISON --> SDT["sdt.update_needs()<br/>+ evaluate_motivation_shift()"]
+        SDT --> GONZALEZ["gonzalez.update_exhaustion()"]
+        GONZALEZ --> ENG["_update_engagement()"]
+    end
+
+    P1 --> P2
+
+    subgraph P2["Phase 2: Social Network + Peer Influence"]
+        direction TB
+        DECAY["network.decay_links(rate=_NETWORK_DECAY_RATE)"]
+        DECAY --> UPDATE_NET["epstein_axtell.update_network()<br/>new links from co-posting"]
+        UPDATE_NET --> P2_LOOP["For each student (not dropped out)"]
+        P2_LOOP --> PEER["epstein_axtell.apply_peer_influence()"]
+        PEER --> COI_BOOST["CoI social_presence boost<br/>from network degree"]
+        COI_BOOST --> RECORD["Record engagement to<br/>weekly_engagement_history"]
+        RECORD --> BAULKE["baulke.advance_phase()"]
+        BAULKE --> DROP{"dropout_phase >= 5?"}
+        DROP -->|Yes| DROPOUT["has_dropped_out = True<br/>dropout_week = week"]
+        DROP -->|No| P2_NEXT[Next student]
+    end
+
+    P2 --> WEEK_END{"More weeks?"}
+    WEEK_END -->|Yes| WEEK_START
+    WEEK_END -->|No| OUTCOMES["_assign_outcomes()<br/>absolute or relative grading"]
+```
+
+---
+
+## Initialization
+
+Before the weekly loop begins, `engine.run()` initializes state for each student:
+
+```
+SimulationState(
+    student_id           = student.id
+    current_engagement   = student.base_engagement_probability
+    academic_integration = student.academic_integration
+    social_integration   = student.social_integration
+    perceived_cost_benefit = student.perceived_cost_benefit
+    courses_active       = first N courses (N = student.enrolled_courses)
+    coi_state            = CommunityOfInquiryState(teaching_presence = inst.teaching_presence_baseline)
+    sdt_needs            = SDTNeedSatisfaction(autonomy, competence, relatedness from persona)
+    current_motivation_type = student.motivation_type
+)
+```
+
+**State overrides** (multi-semester): When `initial_state_overrides` is provided (from `MultiSemesterRunner`), attributes are set via `setattr()` after default initialization. This carries forward evolved values like `dropout_phase`, `cumulative_gpa`, `exhaustion`, and `coi_state`.
+
+---
+
+## Phase 1: Individual Behavior
+
+For each week, every non-dropped student goes through Phase 1 in order:
+
+### Step 1: Unavoidable Withdrawal Check
+
+`UnavoidableWithdrawal.check_withdrawal()` models stochastic life events (medical emergency, family crisis, etc.) that force withdrawal regardless of engagement or dropout phase. The per-week probability is spread from `per_semester_probability` / `total_weeks`.
+
+If triggered, the student is immediately marked as dropped out with `withdrawal_reason` set — the Baulke phase model is bypassed entirely.
+
+### Step 2: Interaction Generation
+
+`_simulate_student_week()` generates 5 types of interactions, in this exact order per course:
+
+```
+1. _sim_lms_logins()    — Poisson-distributed login count
+2. _sim_forum_activity() — forum reads + posts (if course.has_forum)
+3. _sim_assignment()     — submit or miss (if week in course.assignment_weeks)
+4. _sim_live_session()   — attend or skip (if course.has_live_sessions)
+5. _sim_exam()           — take or skip (if week == midterm_week or final_week)
+```
+
+**Interaction generation order diagram:**
+
+```mermaid
+flowchart LR
+    L[LMS Logins] --> F[Forum Activity]
+    F --> A[Assignment]
+    A --> LS[Live Session]
+    LS --> E[Exam]
+
+    style L fill:#e1f5fe
+    style F fill:#e8f5e9
+    style A fill:#fff3e0
+    style LS fill:#f3e5f5
+    style E fill:#ffebee
+```
+
+> **RNG determinism**: This order is critical. Each generator consumes random draws from `self.rng` (numpy) and `random` (stdlib). Changing the order — or adding a new generator between existing ones — shifts all subsequent random draws, changing the entire simulation trajectory.
+
+### Step 3: Theory Updates
+
+After interactions are generated, four theory modules update the student's state:
+
+1. **`tinto.update_integration()`** — updates `academic_integration` and `social_integration` based on this week's interactions
+2. **`garrison.update_presences()`** — updates CoI social, cognitive, and teaching presence based on interactions and active courses
+3. **`sdt.update_needs()`** + **`sdt.evaluate_motivation_shift()`** — updates autonomy/competence/relatedness needs, may shift `current_motivation_type`
+4. **`gonzalez.update_exhaustion()`** — updates `exhaustion.exhaustion_level` based on workload and interactions, modulated by `InstitutionalConfig`
+
+### Step 4: Engagement Update
+
+`_update_engagement()` is the multi-theory engagement composer. It reads state from all theory modules and computes a new `current_engagement` value. See [Engagement Formula](engagement-formula.md) for the full term-by-term breakdown.
+
+---
+
+## Phase 2: Social Network + Peer Influence
+
+Phase 2 runs after ALL students have completed Phase 1 for the week.
+
+### Step 1: Network Link Decay
+
+`network.decay_links(decay_rate=_NETWORK_DECAY_RATE)` — existing link strengths decay by `_NETWORK_DECAY_RATE` (default 0.02) each week. Links that decay below a threshold are removed.
+
+### Step 2: Network Update
+
+`epstein_axtell.update_network()` — new links are formed between students who co-posted in forums during this week. This models the Epstein & Axtell social simulation principle: agents interact and form connections through shared activity.
+
+### Step 3: Per-Student Peer Effects
+
+For each non-dropped student:
+
+1. **Peer influence**: `epstein_axtell.apply_peer_influence()` — a student's engagement is pulled toward the average engagement of their network neighbors
+2. **CoI social_presence boost**: network degree increases `social_presence` by `min(degree * _COI_DEGREE_FACTOR, _COI_DEGREE_CAP)` where `_COI_DEGREE_FACTOR` = 0.005 and `_COI_DEGREE_CAP` = 0.03. Clipped to [`_ENGAGEMENT_CLIP_LO`, `_ENGAGEMENT_CLIP_HI`].
+3. **Engagement recorded**: `state.weekly_engagement_history.append(state.current_engagement)` — this happens AFTER peer influence, ensuring the recorded value reflects the final engagement for the week
+4. **Baulke phase advancement**: `baulke.advance_phase()` evaluates whether the student moves to the next dropout phase (or recovers). See [Dropout Mechanics](dropout-mechanics.md).
+5. **Dropout check**: If `dropout_phase >= 5`, the student is marked as dropped out and `dropout_week` is set.
+
+---
+
+## End-of-Run: Outcome Assignment
+
+After the final week, `_assign_outcomes()` assigns `semester_grade` and `outcome` to each student.
+
+Dispatches based on `grading_config.grading_method`:
+- **Absolute grading** — `_assign_outcomes_absolute()`: each student graded independently against fixed thresholds
+- **Relative grading** — `_assign_outcomes_relative()`: t-score normalization across the cohort, with fallback to absolute if fewer than 2 eligible students or zero variance
+
+See [Grading & GPA](grading-and-gpa.md) for the full classification flow.
+
+---
+
+## Environment & Course Structure
+
+### `ODLEnvironment` Dataclass
+
+The environment defines the semester structure:
+
+| Field | Default | Role |
+|-------|---------|------|
+| `semester_name` | Auto-generated (e.g., "Spring 2026") | Label only |
+| `total_weeks` | 14 | Duration of simulation |
+| `courses` | 4 default courses | Course catalog |
+| `scheduled_events` | Week-keyed events (semester_start, midterm, etc.) | Informational context |
+| `positive_events` | Week-keyed positive events (orientation, financial aid, etc.) | Counter-pressure for engagement |
+
+### `Course` Dataclass
+
+Each course carries Moore transactional distance fields:
+
+| Field | Default | Role |
+|-------|---------|------|
+| `structure_level` | 0.5 | Rigidity of pacing/requirements (Moore TD) |
+| `dialogue_frequency` | 0.3 | Instructor-initiated communication rate (Moore TD) |
+| `instructor_responsiveness` | 0.5 | Speed/quality of instructor replies (Moore TD) |
+| `assignment_weeks` | `[3, 6, 10, 13]` | Weeks when assignments are due |
+| `midterm_week` | 7 | Week of midterm exam |
+| `final_week` | 14 | Week of final exam |
+| `has_forum` | `True` | Whether forum activity is generated |
+| `has_live_sessions` | `False` | Whether live sessions are available |
+
+### `get_week_context()`
+
+Each week, `env.get_week_context(week)` builds a context dict consumed by theory modules:
+
+```python
+{
+    "week": week,
+    "semester_progress": week / total_weeks,
+    "event": scheduled_events.get(week, "regular_week"),
+    "active_assignments": [course_ids with assignments due this week],
+    "is_exam_week": True/False,
+    "total_workload_hours": sum of all courses,
+    "lms_available": True,
+    "positive_event": positive_events.get(week),  # None if no event
+}
+```
+
+### Week Gating
+
+Not all interaction types fire every week:
+
+| Interaction | When it fires |
+|-------------|---------------|
+| LMS logins | Every week |
+| Forum reads/posts | Every week (if `course.has_forum`) |
+| Assignment submission | Only on `course.assignment_weeks` |
+| Live sessions | Every week (if `course.has_live_sessions`) |
+| Exams | Only on `course.midterm_week` and `course.final_week` |
+
+Default course configs create a varied schedule:
+- **CS101**: assignments weeks [3, 6, 10, 13], midterm week 7, final week 14, has live sessions
+- **MATH201**: assignments weeks [2, 5, 8, 11, 13], midterm week 7, final week 14, no live sessions
+- **EDU301**: assignments weeks [4, 9, 13], midterm week 7, final week 14, has live sessions
+- **PSY202**: assignments weeks [3, 6, 10, 13], midterm week 7, final week 14, no live sessions
+
+---
+
+## RNG Determinism
+
+Two RNG sources are seeded in `SimulationEngine.__init__()`:
+
+1. `self.rng = np.random.default_rng(seed)` — numpy Generator, used by most interaction generators
+2. `random.seed(seed)` — Python stdlib, used by some theory modules
+
+**Why both?** Historical — some theory modules use `random.random()` while the engine uses numpy. Both must be seeded for full reproducibility.
+
+**Why order matters:** Within `_simulate_student_week()`, the 5 interaction generators fire sequentially, each consuming draws from `self.rng`. If you insert a new generator between (say) forum and assignment, it shifts all random draws from assignment onward, producing a different simulation even with the same seed.
+
+**Multi-semester note:** `MultiSemesterRunner` reuses the same `SimulationEngine` instance across semesters, so the RNG state continues from where the previous semester left off. This is intentional — it ensures different semesters produce different behavior.
+
+---
+
+## Gotchas
+
+- **Phase 1/Phase 2 boundary is strict** — engagement is updated in Phase 1, but recorded to history in Phase 2 (after peer influence). If you add logging in Phase 1, the engagement value you see is BEFORE peer influence.
+- **Unavoidable withdrawal bypasses Baulke** — a student withdrawn in Phase 1 step 1 never enters `_simulate_student_week()` or `baulke.advance_phase()`. Their `dropout_phase` stays at whatever it was.
+- **`courses_active` is set once** — at initialization, from `student.enrolled_courses`. Students do not drop individual courses during the semester.
+- **State overrides use `setattr()`** — the multi-semester carry-over sets attributes directly on `SimulationState` (which is mutable). This is the one place where direct mutation is intentional.
+- **`weekly_engagement_history` is per-semester** — in multi-semester mode, the carry-over resets this to `[]` for each new semester. The `MultiSemesterResult.all_records` aggregates across semesters.
+- **Network is shared across all students** — `SocialNetwork` is a single object. In multi-semester mode, it carries over with heavier decay (`network_link_decay` = 0.30 default vs. weekly `_NETWORK_DECAY_RATE` = 0.02).
+
+---
+
+*See also: [Pipeline Walkthrough](pipeline-walkthrough.md) for the full execution path, [Engagement Formula](engagement-formula.md) for the multi-theory composer, [Theory Module Reference](theory-modules.md) for all 11 modules, [Dropout Mechanics](dropout-mechanics.md) for the Baulke phase model, [Grading & GPA](grading-and-gpa.md) for outcome classification, [Calibration & Analysis](calibration-and-analysis.md) for CalibrationMap and Sobol, [Data Export](data-export.md) for CSV output formats.*

--- a/docs/wiki/simulation-loop.md
+++ b/docs/wiki/simulation-loop.md
@@ -128,7 +128,7 @@ flowchart LR
     style E fill:#ffebee
 ```
 
-> **RNG determinism**: This order is critical. Each generator consumes random draws from `self.rng` (numpy) and `random` (stdlib). Changing the order — or adding a new generator between existing ones — shifts all subsequent random draws, changing the entire simulation trajectory.
+> **RNG determinism**: This order is critical. Each interaction generator consumes random draws from `self.rng` (numpy). Changing the order — or adding a new generator between existing ones — shifts all subsequent numpy draws, changing the entire simulation trajectory. Note: some theory modules separately use `random` (stdlib), which is also seeded for determinism.
 
 ### Step 3: Theory Updates
 

--- a/docs/wiki/theory-modules.md
+++ b/docs/wiki/theory-modules.md
@@ -72,7 +72,7 @@ sequence.
 
 | | Fields |
 |---|--------|
-| **Reads** | `StudentPersona.is_employed`, `.weekly_work_hours`, `.has_family_responsibilities`, `.financial_stress`, `.disability_severity`, `.self_regulation`, `.personality.conscientiousness` |
+| **Reads** | `StudentPersona.employment_intensity`, `.family_responsibility_level`, `.financial_stress`, `.disability_severity`, `.self_regulation`, `.personality.conscientiousness` |
 | **Writes** | `SimulationState.coping_factor`, `SimulationState.env_shock_remaining`, `.env_shock_magnitude` (shock state managed in `contribute_engagement_delta()`) |
 | **When** | Engagement update -- `contribute_engagement_delta()` dispatched at `_ENGAGEMENT_ORDER = 200` |
 
@@ -81,7 +81,7 @@ sequence.
 | Constant | Default | Purpose |
 |----------|---------|---------|
 | `_OVERWORK_THRESHOLD_HOURS` | 30 | Weekly hours triggering overwork penalty |
-| `_OVERWORK_PENALTY` | 0.025 | Engagement erosion from overwork |
+| `_EMPLOYMENT_PRESSURE_FACTOR` | 0.04 | Continuous employment pressure erosion |
 | `_FAMILY_PENALTY` | 0.02 | Engagement erosion from family responsibilities |
 | `_FINANCIAL_STRESS_THRESHOLD` | 0.5 | Stress level triggering financial penalty |
 | `_FINANCIAL_PENALTY` | 0.015 | Engagement erosion from financial stress |
@@ -104,7 +104,7 @@ sequence.
 
 | | Fields |
 |---|--------|
-| **Reads** | `SimulationState.perceived_mastery`, `.perceived_mastery_count`, `.missed_assignments_streak`, `.coi_state` (all 3 presences), `.social_integration`; `StudentPersona.is_employed`, `.financial_stress`, `.has_family_responsibilities`; Moore avg TD |
+| **Reads** | `SimulationState.perceived_mastery`, `.perceived_mastery_count`, `.missed_assignments_streak`, `.coi_state` (all 3 presences), `.social_integration`; `StudentPersona.employment_intensity`, `.financial_stress`, `.family_responsibility_level`; Moore avg TD |
 | **Writes** | `SimulationState.perceived_cost_benefit` |
 | **When** | Engagement update -- `contribute_engagement_delta()` dispatched at `_ENGAGEMENT_ORDER = 900`; conditional gate fires only on graded-item weeks, exam weeks, or missed streak >= 2 |
 
@@ -119,7 +119,7 @@ sequence.
 | `_COI_COMPOSITE_FACTOR` | 0.02 | CoI composite influence on value |
 | `_GPA_CB_FACTOR` | 0.01 | CB sensitivity to perceived mastery |
 | `_OC_FACTOR` | 0.015 | Opportunity cost pressure per week |
-| `_OC_STRESS_THRESHOLD` | 0.5 | Financial stress above this triggers OC |
+| *(removed)* | — | OC now uses continuous `employment_intensity × financial_stress` (no threshold) |
 | `_TIME_DISCOUNT_FACTOR` | 0.008 | Time-based CB erosion per week |
 | `_CLIP_LO` / `_HI` | 0.05 / 0.95 | Cost-benefit bounds |
 
@@ -314,7 +314,7 @@ See [dropout-mechanics.md](dropout-mechanics.md) for the full 6-phase state mach
 
 | | Fields |
 |---|--------|
-| **Reads** | `StudentPersona.is_employed`, `.weekly_work_hours`, `.has_family_responsibilities`, `.financial_stress`, `.self_regulation`, `.personality.conscientiousness`; week context (`active_assignments`, `positive_event`) |
+| **Reads** | `StudentPersona.employment_intensity`, `.family_responsibility_level`, `.financial_stress`, `.self_regulation`, `.personality.conscientiousness`; week context (`active_assignments`, `positive_event`) |
 | **Writes** | `SimulationState.exhaustion` (`.exhaustion_level`, `.recovery_capacity`) |
 | **When** | Phase 1 -- after SDT, before engagement update. Also `exhaustion_engagement_effect()` called inside `_update_engagement()` |
 

--- a/docs/wiki/theory-modules.md
+++ b/docs/wiki/theory-modules.md
@@ -1,0 +1,487 @@
+# Theory Module Reference
+
+SynthEd integrates 11 theoretical frameworks as stateless Python classes plus one event handler.
+Each module reads specific persona/state fields, writes to specific state fields, and fires at a
+well-defined point in the weekly loop.
+
+> **Convention**: Every module lives in `synthed/simulation/theories/` and exposes `_UPPERCASE`
+> class-level constants. Override them via Sobol or NSGA-II prefix routing (see
+> [calibration-and-analysis.md](calibration-and-analysis.md)).
+
+---
+
+## Module Summary Table
+
+| # | Module | Class | File | Theory | Called In |
+|---|--------|-------|------|--------|-----------|
+| 1 | Tinto Integration | `TintoIntegration` | `theories/tinto.py` | Tinto (1975) | Phase 1 |
+| 2 | Bean & Metzner Pressure | `BeanMetznerPressure` | `theories/bean_metzner.py` | Bean & Metzner (1985) | Engagement update |
+| 3 | Kember Cost-Benefit | `KemberCostBenefit` | `theories/kember.py` | Kember (1989) | Engagement update |
+| 4 | Baulke Dropout Phase | `BaulkeDropoutPhase` | `theories/baulke.py` | Baeulke et al. (2022) | Phase 2 |
+| 5 | Garrison CoI | `GarrisonCoI` | `theories/garrison_coi.py` | Garrison et al. (2000) | Phase 1 |
+| 6 | Moore Transactional Distance | `MooreTransactionalDistance` | `theories/moore_td.py` | Moore (1993) | Engagement update |
+| 7 | Epstein & Axtell Peer Influence | `EpsteinAxtellPeerInfluence` | `theories/epstein_axtell.py` | Epstein & Axtell (1996) | Phase 2 |
+| 8 | Rovai Persistence | `RovaiPersistence` | `theories/rovai.py` | Rovai (2003) | Engagement update |
+| 9 | SDT Motivation Dynamics | `SDTMotivationDynamics` | `theories/sdt_motivation.py` | Deci & Ryan (1985) | Phase 1 |
+| 10 | Gonzalez Exhaustion | `GonzalezExhaustion` | `theories/academic_exhaustion.py` | Gonzalez et al. (2025) | Phase 1 + Engagement |
+| 11 | Unavoidable Withdrawal | `UnavoidableWithdrawal` | `theories/unavoidable_withdrawal.py` | (life events) | Phase 1 (first check) |
+| -- | Positive Event Handler | `PositiveEventHandler` | `theories/positive_events.py` | (counter-pressure) | Engagement update |
+
+> For academic citations and factor cluster tables, see `docs/THEORY.md`.
+
+---
+
+## Detailed Module Specifications
+
+### 1. Tinto Integration
+
+**Source**: `theories/tinto.py` -- Tinto (1975)
+
+| | Fields |
+|---|--------|
+| **Reads** | `StudentPersona.personality.extraversion`, interaction records (`assignment_submit`, `exam`, `forum_post`, `forum_read`, `live_session`) |
+| **Writes** | `SimulationState.academic_integration`, `SimulationState.social_integration` |
+| **When** | Phase 1 -- after `_simulate_student_week()`, before engagement update |
+
+**Key constants:**
+
+| Constant | Default | Purpose |
+|----------|---------|---------|
+| `_ACADEMIC_QUALITY_FACTOR` | 0.05 | Academic integration boost per quality delta |
+| `_ACADEMIC_EROSION` | 0.02 | Weekly erosion when no academic activity |
+| `_FORUM_POST_BOOST` | 0.03 | Social integration boost per forum post |
+| `_MAX_POST_CREDIT` | 3 | Max forum posts that count |
+| `_LIVE_SESSION_BOOST` | 0.02 | Social integration boost for live attendance |
+| `_LURK_BOOST` | 0.005 | Minimal boost for reading without posting |
+| `_ISOLATION_EROSION` | 0.03 | Durkheim: erosion when fully isolated |
+| `_ACADEMIC_CLIP_LO` / `_HI` | 0.01 / 0.95 | Academic integration bounds |
+| `_SOCIAL_CLIP_LO` / `_HI` | 0.01 / 0.80 | Social integration bounds |
+
+**InstitutionalConfig**: None.
+
+---
+
+### 2. Bean & Metzner Pressure
+
+**Source**: `theories/bean_metzner.py` -- Bean & Metzner (1985)
+
+| | Fields |
+|---|--------|
+| **Reads** | `StudentPersona.is_employed`, `.weekly_work_hours`, `.has_family_responsibilities`, `.financial_stress`, `.disability_severity`, `.self_regulation`, `.personality.conscientiousness` |
+| **Writes** | `SimulationState.coping_factor`, `SimulationState.env_shock_remaining`, `.env_shock_magnitude` (indirectly via engine) |
+| **When** | Engagement update -- `calculate_environmental_pressure()` and `update_coping()` called inside `_update_engagement()` |
+
+**Key constants:**
+
+| Constant | Default | Purpose |
+|----------|---------|---------|
+| `_OVERWORK_THRESHOLD_HOURS` | 30 | Weekly hours triggering overwork penalty |
+| `_OVERWORK_PENALTY` | 0.025 | Engagement erosion from overwork |
+| `_FAMILY_PENALTY` | 0.02 | Engagement erosion from family responsibilities |
+| `_FINANCIAL_STRESS_THRESHOLD` | 0.5 | Stress level triggering financial penalty |
+| `_FINANCIAL_PENALTY` | 0.015 | Engagement erosion from financial stress |
+| `_DISABILITY_PENALTY` | 0.015 | Engagement erosion from disability challenges |
+| `_COPING_MAX` | 0.50 | Maximum coping factor (50% pressure reduction) |
+| `_COPING_GROWTH_RATE` | 0.03 | Weekly coping growth rate |
+| `_COPING_REG_WEIGHT` | 0.60 | Self-regulation weight in coping aptitude |
+| `_COPING_CONSC_WEIGHT` | 0.40 | Conscientiousness weight in coping aptitude |
+| `_SHOCK_BASE_PROB` | 0.04 | Base probability of environmental shock |
+| `_SHOCK_MIN_DURATION` / `_MAX` | 1 / 3 | Shock duration range (weeks) |
+| `_SHOCK_MIN_MAGNITUDE` / `_MAX` | 0.3 / 1.0 | Shock magnitude range |
+
+**InstitutionalConfig**: None directly (but shocks affect engagement which is modulated elsewhere).
+
+---
+
+### 3. Kember Cost-Benefit
+
+**Source**: `theories/kember.py` -- Kember (1989)
+
+| | Fields |
+|---|--------|
+| **Reads** | `SimulationState.perceived_mastery`, `.perceived_mastery_count`, `.missed_assignments_streak`, `.coi_state` (all 3 presences), `.social_integration`; `StudentPersona.is_employed`, `.financial_stress`, `.has_family_responsibilities`; Moore avg TD |
+| **Writes** | `SimulationState.perceived_cost_benefit` |
+| **When** | Engagement update -- called when graded items submitted, exam weeks, or missed streak >= 2 |
+
+**Key constants:**
+
+| Constant | Default | Purpose |
+|----------|---------|---------|
+| `_QUALITY_FACTOR` | 0.04 | CB sensitivity to academic quality |
+| `_MISSED_PENALTY` | 0.03 | Penalty per missed-assignment streak event |
+| `_TD_PENALTY_FACTOR` | 0.02 | Moore TD influence on perceived value |
+| `_TEACHING_PRESENCE_FACTOR` | 0.03 | Garrison teaching presence boost |
+| `_COI_COMPOSITE_FACTOR` | 0.02 | CoI composite influence on value |
+| `_GPA_CB_FACTOR` | 0.01 | CB sensitivity to perceived mastery |
+| `_OC_FACTOR` | 0.015 | Opportunity cost pressure per week |
+| `_OC_STRESS_THRESHOLD` | 0.5 | Financial stress above this triggers OC |
+| `_TIME_DISCOUNT_FACTOR` | 0.008 | Time-based CB erosion per week |
+| `_CLIP_LO` / `_HI` | 0.05 / 0.95 | Cost-benefit bounds |
+
+**InstitutionalConfig**: `instructional_design_quality` scales `_QUALITY_FACTOR` via `scale_by()`.
+
+---
+
+### 4. Baulke Dropout Phase
+
+**Source**: `theories/baulke.py` -- Baeulke et al. (2022)
+
+| | Fields |
+|---|--------|
+| **Reads** | `SimulationState.current_engagement`, `.weekly_engagement_history`, `.coi_state.cognitive_presence`, `.missed_assignments_streak`, `.social_integration`, `.perceived_cost_benefit`, `.perceived_mastery`, `.perceived_mastery_count`, `.env_shock_remaining`, `.env_shock_magnitude`, `.exhaustion`; `StudentPersona.base_dropout_risk`, `.financial_stress`; Moore avg TD |
+| **Writes** | `SimulationState.dropout_phase`, `.memory` |
+| **When** | Phase 2 -- after peer influence, after engagement history recorded |
+
+See [dropout-mechanics.md](dropout-mechanics.md) for the full 6-phase state machine.
+
+**Key constants:** See [dropout-mechanics.md](dropout-mechanics.md) for the complete threshold table.
+
+**InstitutionalConfig**: None directly (but modulates upstream signals like engagement and cost-benefit).
+
+---
+
+### 5. Garrison CoI
+
+**Source**: `theories/garrison_coi.py` -- Garrison et al. (2000)
+
+| | Fields |
+|---|--------|
+| **Reads** | `StudentPersona.personality.extraversion`, `.institutional_support_access`; `Course.dialogue_frequency`, `.instructor_responsiveness`; interaction records (`forum_post`, `live_session`, `assignment_submit`, `exam`) |
+| **Writes** | `SimulationState.coi_state.social_presence`, `.cognitive_presence`, `.teaching_presence` |
+| **When** | Phase 1 -- after Tinto, before SDT |
+
+**Key constants:**
+
+| Constant | Default | Purpose |
+|----------|---------|---------|
+| `_FORUM_POST_SOCIAL_BOOST` | 0.03 | Social presence boost per forum post |
+| `_LIVE_SESSION_SOCIAL_BOOST` | 0.02 | Social presence boost per live session |
+| `_EXTRAVERSION_FACTOR` | 0.01 | Extraversion influence on social presence |
+| `_SOCIAL_DECAY` | 0.02 | Weekly social presence decay |
+| `_COGNITIVE_QUALITY_FACTOR` | 0.04 | Cognitive presence boost per quality delta |
+| `_DEEP_POST_BOOST` | 0.02 | Boost for substantive forum posts |
+| `_DEEP_POST_MIN_LENGTH` | 100 | Min post length for deep post credit |
+| `_COGNITIVE_DECAY` | 0.01 | Weekly cognitive presence decay |
+| `_DIALOGUE_FACTOR` | 0.02 | Teaching presence boost per dialogue delta |
+| `_RESPONSIVENESS_FACTOR` | 0.01 | Teaching presence boost per responsiveness delta |
+| `_SUPPORT_ACCESS_FACTOR` | 0.01 | Institutional support influence |
+| `_PRESENCE_CLIP_LO` / `_HI` | 0.01 / 0.95 | Bounds for all three presences |
+
+**InstitutionalConfig**: `teaching_presence_baseline` sets the initial `teaching_presence` value in `CommunityOfInquiryState` (direct init, not via `scale_by()`).
+
+---
+
+### 6. Moore Transactional Distance
+
+**Source**: `theories/moore_td.py` -- Moore (1993)
+
+| | Fields |
+|---|--------|
+| **Reads** | `Course.structure_level`, `.dialogue_frequency`, `.instructor_responsiveness`; `StudentPersona.learner_autonomy`; `SimulationState.courses_active` |
+| **Writes** | None (returns a float consumed by engagement update and Kember) |
+| **When** | Engagement update -- `average()` called inside `_update_engagement()` and passed to `kember.recalculate()` |
+
+**Key constants:**
+
+| Constant | Default | Purpose |
+|----------|---------|---------|
+| `_STRUCTURE_WEIGHT` | 0.35 | Weight of course structure (raises TD) |
+| `_DIALOGUE_WEIGHT` | 0.30 | Weight of dialogue frequency (lowers TD) |
+| `_AUTONOMY_WEIGHT` | 0.25 | Weight of learner autonomy (lowers TD) |
+| `_RESPONSIVENESS_WEIGHT` | 0.10 | Weight of instructor responsiveness (lowers TD) |
+| `_OFFSET` | 0.30 | Baseline offset to centre TD distribution |
+| `_DEFAULT_TD` | 0.5 | Fallback when no active courses |
+
+**Formula**: `TD = structure * 0.35 - dialogue * 0.30 - autonomy * 0.25 - responsiveness * 0.10 + 0.30`, clipped to [0, 1].
+
+**InstitutionalConfig**: None.
+
+---
+
+### 7. Epstein & Axtell Peer Influence
+
+**Source**: `theories/epstein_axtell.py` -- Epstein & Axtell (1996)
+
+| | Fields |
+|---|--------|
+| **Reads** | Interaction records (`forum_post`, `live_session`); `SocialNetwork` (peer states); `SimulationState.current_engagement`, `.social_integration` of all peers |
+| **Writes** | `SocialNetwork` (link formation); `SimulationState.current_engagement`, `.social_integration` |
+| **When** | Phase 2 -- `update_network()` then `apply_peer_influence()` per student |
+
+**Key constants:**
+
+| Constant | Default | Purpose |
+|----------|---------|---------|
+| `_FORUM_LINK_WEIGHT` | 0.05 | Tie strength from co-posting |
+| `_LIVE_LINK_WEIGHT` | 0.03 | Tie strength from co-attending live session |
+| `_SOCIAL_DEGREE_FACTOR` | 0.003 | Social integration boost per network degree |
+| `_SOCIAL_DEGREE_CAP` | 0.02 | Max social integration boost from peers |
+| `_SAMPLING_THRESHOLD` | 40 | Group size above which peers are sampled |
+| `_DEGREE_CAP_PER_ACTIVITY` | 20 | Max peers sampled per activity type |
+| `_ENGAGEMENT_CLIP_LO` / `_HI` | 0.01 / 0.99 | Engagement bounds |
+| `_SOCIAL_CLIP_HI` | 0.80 | Social integration upper bound |
+
+**Three influence channels:**
+1. **Engagement contagion** -- peers pull engagement toward local mean
+2. **Dropout contagion** -- peers in dropout phases penalize engagement
+3. **Social integration reinforcement** -- degree boosts social integration (Tinto via ABSS)
+
+**InstitutionalConfig**: None.
+
+---
+
+### 8. Rovai Persistence
+
+**Source**: `theories/rovai.py` -- Rovai (2003)
+
+| | Fields |
+|---|--------|
+| **Reads** | `StudentPersona.self_regulation`, `.goal_commitment`, `.self_efficacy`, `.learner_autonomy`, `.disability_severity`, `.institutional_support_access` |
+| **Writes** | None (returns floats consumed by engagement update) |
+| **When** | Engagement update -- `regulation_buffer()` and `engagement_floor()` called inside `_update_engagement()` |
+
+**Key constants:**
+
+| Constant | Default | Purpose |
+|----------|---------|---------|
+| `_REGULATION_FACTOR` | 0.03 | Self-regulation sensitivity for buffer |
+| `_FLOOR_REGULATION_WEIGHT` | 0.15 | Self-regulation weight in floor |
+| `_FLOOR_GOAL_WEIGHT` | 0.12 | Goal commitment weight in floor |
+| `_FLOOR_EFFICACY_WEIGHT` | 0.10 | Self-efficacy weight in floor |
+| `_FLOOR_AUTONOMY_WEIGHT` | 0.08 | Learner autonomy weight in floor |
+| `_FLOOR_SCALE` | 0.50 | Scale factor; max floor ~0.22 |
+| `_DISABILITY_SUPPORT_THRESHOLD` | 0.50 | Support level above which disability penalty vanishes |
+| `_DISABILITY_FLOOR_PENALTY` | 0.40 | Max floor reduction factor at zero support |
+
+**Formulas:**
+- Buffer: `(self_regulation - 0.5) * 0.03`
+- Floor: `(reg * 0.15 + goal * 0.12 + efficacy * 0.10 + autonomy * 0.08) * 0.50`, reduced by disability/accessibility gap
+
+**InstitutionalConfig**: None directly, but `institutional_support_access` from persona interacts with disability penalty.
+
+---
+
+### 9. SDT Motivation Dynamics
+
+**Source**: `theories/sdt_motivation.py` -- Deci & Ryan (1985)
+
+| | Fields |
+|---|--------|
+| **Reads** | `StudentPersona.learner_autonomy`, `.self_regulation`, `.self_efficacy`; `SimulationState.social_integration`, `.coi_state.social_presence`, `.perceived_mastery`, `.perceived_mastery_count`, `.missed_assignments_streak`; interaction records |
+| **Writes** | `SimulationState.sdt_needs` (autonomy, competence, relatedness), `.current_motivation_type` |
+| **When** | Phase 1 -- after Garrison CoI, before engagement update |
+
+**Key constants:**
+
+| Constant | Default | Purpose |
+|----------|---------|---------|
+| `_AUTONOMY_FACTOR` | 0.03 | Autonomy need sensitivity |
+| `_AUTONOMY_REGULATION_FACTOR` | 0.01 | Self-regulation contribution |
+| `_AUTONOMY_DECAY` | 0.005 | Weekly autonomy decay |
+| `_COMPETENCE_QUALITY_FACTOR` | 0.06 | Competence sensitivity to quality |
+| `_COMPETENCE_EROSION` | 0.02 | Erosion when no academic activity |
+| `_COMPETENCE_STREAK_PENALTY` | 0.02 | Per-streak competence erosion |
+| `_COMPETENCE_STREAK_CAP` | 3 | Max streak multiplier |
+| `_COMPETENCE_GPA_FACTOR` | 0.008 | Competence sensitivity to mastery |
+| `_RELATEDNESS_SOCIAL_FACTOR` | 0.02 | Social integration influence |
+| `_RELATEDNESS_COI_FACTOR` | 0.02 | CoI social presence influence |
+| `_RELATEDNESS_FORUM_BOOST` | 0.015 | Boost per forum post |
+| `_RELATEDNESS_LIVE_BOOST` | 0.01 | Boost per live session |
+| `_RELATEDNESS_DECAY` | 0.01 | Weekly relatedness decay |
+| `_NEED_CLIP_LO` / `_HI` | 0.01 / 0.99 | Bounds for all needs |
+| `_INTRINSIC_THRESHOLD` | 0.60 | Composite above this = intrinsic |
+| `_EXTRINSIC_THRESHOLD` | 0.35 | Composite above this = extrinsic |
+
+**Composite weights** (in `SDTNeedSatisfaction`):
+- `_AUTONOMY_COMPOSITE_WEIGHT` = 0.35
+- `_COMPETENCE_COMPOSITE_WEIGHT` = 0.40
+- `_RELATEDNESS_COMPOSITE_WEIGHT` = 0.25
+
+**Motivation type thresholds**: composite >= 0.60 = intrinsic, >= 0.35 = extrinsic, below = amotivation.
+
+**InstitutionalConfig**: None.
+
+---
+
+### 10. Gonzalez Exhaustion
+
+**Source**: `theories/academic_exhaustion.py` -- Gonzalez et al. (2025)
+
+| | Fields |
+|---|--------|
+| **Reads** | `StudentPersona.is_employed`, `.weekly_work_hours`, `.has_family_responsibilities`, `.financial_stress`, `.self_regulation`, `.personality.conscientiousness`; week context (`active_assignments`, `positive_event`) |
+| **Writes** | `SimulationState.exhaustion` (`.exhaustion_level`, `.recovery_capacity`) |
+| **When** | Phase 1 -- after SDT, before engagement update. Also `exhaustion_engagement_effect()` called inside `_update_engagement()` |
+
+**Key constants:**
+
+| Constant | Default | Purpose |
+|----------|---------|---------|
+| `_ASSIGNMENT_LOAD_WEIGHT` | 0.025 | Exhaustion from assignment load |
+| `_STRESSOR_WEIGHT` | 0.020 | Exhaustion from environmental stressors |
+| `_LOW_REGULATION_WEIGHT` | 0.015 | Amplification from low self-regulation |
+| `_RECOVERY_BASE` | 0.035 | Base recovery rate |
+| `_RECOVERY_CAP_DECAY` | 0.02 | Recovery capacity degradation rate |
+| `_RECOVERY_CAP_REGEN` | 0.01 | Recovery capacity regeneration rate |
+| `_ENGAGEMENT_IMPACT` | 0.04 | Engagement drag per unit of exhaustion |
+| `_DROPOUT_THRESHOLD` | 0.70 | Exhaustion level that accelerates Baulke |
+
+**Recovery capacity**: degrades when `exhaustion_level > 0.60`, regenerates when `< 0.30`. Range [0.1, 1.0].
+
+**InstitutionalConfig**:
+- `curriculum_flexibility` scales `_ASSIGNMENT_LOAD_WEIGHT` via `scale_by()` (inverted: high flexibility = less load)
+- `support_services_quality` scales `_RECOVERY_BASE` via `scale_by()`
+
+---
+
+### 11. Unavoidable Withdrawal
+
+**Source**: `theories/unavoidable_withdrawal.py`
+
+| | Fields |
+|---|--------|
+| **Reads** | `SimulationState.has_dropped_out` |
+| **Writes** | `SimulationState.has_dropped_out`, `.dropout_week`, `.withdrawal_reason`, `.memory` |
+| **When** | Phase 1 -- first check before `_simulate_student_week()` |
+
+**Not a phase-model module.** This models catastrophic life events that force immediate withdrawal
+regardless of engagement or motivation. It bypasses the Baulke dropout-phase process entirely.
+
+**Initialization**: takes `per_semester_probability` and `total_weeks`. Converts to weekly probability
+via: `p_week = 1 - (1 - p_semester)^(1/N)`.
+
+**Event types** (weighted):
+
+| Event | Weight |
+|-------|--------|
+| `serious_illness` | 0.30 |
+| `family_emergency` | 0.20 |
+| `forced_relocation` | 0.15 |
+| `career_change` | 0.15 |
+| `military_deployment` | 0.10 |
+| `death` | 0.05 |
+| `legal_issues` | 0.05 |
+
+**InstitutionalConfig**: None.
+
+---
+
+### Positive Event Handler (not a theory module)
+
+**Source**: `theories/positive_events.py`
+
+| | Fields |
+|---|--------|
+| **Reads** | Week context (`positive_event` key) |
+| **Writes** | `SimulationState.social_integration`, `.perceived_cost_benefit`, `.coi_state.teaching_presence` |
+| **When** | Engagement update -- returns engagement boost, applies side effects directly |
+
+**Defined events:**
+
+| Event | Engagement Boost | Side Effects |
+|-------|-----------------|--------------|
+| `orientation_welcome` | +0.03 | social_integration +0.02, teaching_presence +0.03 |
+| `financial_aid_disbursement` | +0.02 | cost_benefit +0.03 |
+| `semester_break` | +0.01 | (exhaustion recovery via context) |
+| `holiday_boost` | +0.015 | -- |
+| `peer_study_group` | +0.02 | social_integration +0.015 |
+
+---
+
+## Theory Interaction Graph
+
+Modules do not call each other directly. They interact through shared state variables.
+When Module A writes to a state field that Module B reads, a dependency exists.
+
+```mermaid
+graph LR
+    subgraph "State Variables"
+        ENG[current_engagement]
+        AI[academic_integration]
+        SI[social_integration]
+        CB[perceived_cost_benefit]
+        COI[coi_state]
+        SDT[sdt_needs / motivation_type]
+        EX[exhaustion]
+        DP[dropout_phase]
+        PM[perceived_mastery]
+        NET[SocialNetwork]
+    end
+
+    Tinto -->|writes| AI
+    Tinto -->|writes| SI
+    AI -->|read by| ENG
+    SI -->|read by| ENG
+    SI -->|read by| Baulke
+    SI -->|read by| SDTMod[SDT]
+
+    BeanMetzner -->|affects| ENG
+    BeanMetzner -->|writes shocks| Baulke
+
+    Kember -->|writes| CB
+    CB -->|read by| Baulke
+    CB -->|feeds back to| ENG
+
+    Garrison -->|writes| COI
+    COI -->|read by| ENG
+    COI -->|read by| Kember
+    COI -->|read by| SDTMod
+    COI -->|read by| Baulke
+
+    Moore -->|returns TD| ENG
+    Moore -->|returns TD| Kember
+    Moore -->|returns TD| Baulke
+
+    EpsteinAxtell -->|writes| NET
+    EpsteinAxtell -->|writes| ENG
+    EpsteinAxtell -->|writes| SI
+    NET -->|boosts| COI
+
+    Rovai -->|buffer + floor| ENG
+
+    SDTMod -->|writes| SDT
+    SDT -->|read by| ENG
+
+    Gonzalez -->|writes| EX
+    EX -->|drag on| ENG
+    EX -->|accelerates| Baulke
+
+    ENG -->|read by| Baulke
+    PM -->|read by| Baulke
+    PM -->|read by| Kember
+    PM -->|read by| SDTMod
+```
+
+**Key cross-module dependencies:**
+
+1. **Tinto -> Engagement -> Baulke**: Academic/social integration feed engagement, which is the primary Baulke phase trigger
+2. **Garrison CoI -> Kember -> Baulke**: CoI presences modulate cost-benefit, which gates Phase 3->4
+3. **Gonzalez -> Baulke**: Exhaustion above `_DROPOUT_THRESHOLD` (0.70) accelerates phase transitions
+4. **Moore -> Kember + Engagement**: Transactional distance penalizes both cost-benefit and engagement
+5. **Epstein & Axtell -> Tinto + Engagement**: Peer influence modifies social integration and engagement after individual phase
+6. **SDT -> Engagement**: Motivation type (intrinsic/extrinsic/amotivation) adds or subtracts from engagement
+7. **Bean & Metzner shocks -> Baulke**: Severe shocks (`magnitude > 0.7`) can trigger Phase 2->3 directly
+
+---
+
+## Gotchas
+
+- **Stateless classes, stateful constants**: Theory modules are stateless (no `self.xxx` state between calls), but their class-level `_UPPERCASE` constants are the tuning surface for Sobol/NSGA-II. Do not confuse the two.
+
+- **Call order matters for RNG**: Within Phase 1, the order is Tinto -> Garrison -> SDT -> Gonzalez -> Engagement update. Changing this order changes RNG consumption and breaks determinism.
+
+- **Moore returns, never writes**: `MooreTransactionalDistance` is the only module that never writes to `SimulationState`. It returns a float consumed by `_update_engagement()` and `kember.recalculate()`. This means its effect is always mediated.
+
+- **Epstein & Axtell fires in Phase 2**: Unlike all other modules, peer influence runs after all individual students have been processed. This is the Epstein & Axtell (1996) two-phase design -- individuals first, then social effects.
+
+- **Engagement update is not a module**: `_update_engagement()` lives in `engine.py`, not in `theories/`. It orchestrates calls to Bean & Metzner, Rovai, Moore, Kember, Gonzalez, and PositiveEventHandler. It is the most complex single method in the codebase.
+
+- **`perceived_mastery` vs `cumulative_gpa`**: Theory modules that need academic performance (Kember, SDT, Baulke) read `perceived_mastery` (raw quality, no floor), NOT `cumulative_gpa` (transcript GPA with floor). See [grading-and-gpa.md](grading-and-gpa.md).
+
+- **Unavoidable withdrawal is checked first**: Before any interactions are generated for a student in a week, the unavoidable withdrawal check runs. If triggered, all subsequent processing (interactions, theory updates, engagement) is skipped via `continue`.
+
+- **`scale_by()` neutrality**: When `InstitutionalConfig` param = 0.5, `scale_by()` returns the constant unchanged (`0.7 + 0.6 * 0.5 = 1.0`). Only Kember (`instructional_design_quality`) and Gonzalez (`curriculum_flexibility`, `support_services_quality`) use it.
+
+---
+
+*See also: [simulation-loop.md](simulation-loop.md) for the weekly execution order, [engagement-formula.md](engagement-formula.md) for the full engagement update decomposition, [dropout-mechanics.md](dropout-mechanics.md) for the Baulke phase model.*

--- a/docs/wiki/theory-modules.md
+++ b/docs/wiki/theory-modules.md
@@ -4,6 +4,11 @@ SynthEd integrates 11 theoretical frameworks as stateless Python classes plus on
 Each module reads specific persona/state fields, writes to specific state fields, and fires at a
 well-defined point in the weekly loop.
 
+Since **v1.6.0**, theories that participate in the engagement composition step implement the
+`contribute_engagement_delta()` protocol method. The engine's `_update_engagement()` dispatches to
+all implementing modules in ascending `_ENGAGEMENT_ORDER`, replacing the previous ad-hoc call
+sequence.
+
 > **Convention**: Every module lives in `synthed/simulation/theories/` and exposes `_UPPERCASE`
 > class-level constants. Override them via Sobol or NSGA-II prefix routing (see
 > [calibration-and-analysis.md](calibration-and-analysis.md)).
@@ -12,20 +17,20 @@ well-defined point in the weekly loop.
 
 ## Module Summary Table
 
-| # | Module | Class | File | Theory | Called In |
-|---|--------|-------|------|--------|-----------|
-| 1 | Tinto Integration | `TintoIntegration` | `theories/tinto.py` | Tinto (1975) | Phase 1 |
-| 2 | Bean & Metzner Pressure | `BeanMetznerPressure` | `theories/bean_metzner.py` | Bean & Metzner (1985) | Engagement update |
-| 3 | Kember Cost-Benefit | `KemberCostBenefit` | `theories/kember.py` | Kember (1989) | Engagement update |
-| 4 | Baulke Dropout Phase | `BaulkeDropoutPhase` | `theories/baulke.py` | Baeulke et al. (2022) | Phase 2 |
-| 5 | Garrison CoI | `GarrisonCoI` | `theories/garrison_coi.py` | Garrison et al. (2000) | Phase 1 |
-| 6 | Moore Transactional Distance | `MooreTransactionalDistance` | `theories/moore_td.py` | Moore (1993) | Engagement update |
-| 7 | Epstein & Axtell Peer Influence | `EpsteinAxtellPeerInfluence` | `theories/epstein_axtell.py` | Epstein & Axtell (1996) | Phase 2 |
-| 8 | Rovai Persistence | `RovaiPersistence` | `theories/rovai.py` | Rovai (2003) | Engagement update |
-| 9 | SDT Motivation Dynamics | `SDTMotivationDynamics` | `theories/sdt_motivation.py` | Deci & Ryan (1985) | Phase 1 |
-| 10 | Gonzalez Exhaustion | `GonzalezExhaustion` | `theories/academic_exhaustion.py` | Gonzalez et al. (2025) | Phase 1 + Engagement |
-| 11 | Unavoidable Withdrawal | `UnavoidableWithdrawal` | `theories/unavoidable_withdrawal.py` | (life events) | Phase 1 (first check) |
-| -- | Positive Event Handler | `PositiveEventHandler` | `theories/positive_events.py` | (counter-pressure) | Engagement update |
+| # | Module | Class | File | Theory | `_PHASE_ORDER` | `_ENGAGEMENT_ORDER` | Called In |
+|---|--------|-------|------|--------|:--------------:|:-------------------:|-----------|
+| 1 | Tinto Integration | `TintoIntegration` | `theories/tinto.py` | Tinto (1975) | 10 | 100 | Phase 1 + Engagement |
+| 2 | Bean & Metzner Pressure | `BeanMetznerPressure` | `theories/bean_metzner.py` | Bean & Metzner (1985) | — | 200 | Engagement |
+| 3 | Kember Cost-Benefit | `KemberCostBenefit` | `theories/kember.py` | Kember (1989) | — | 900 | Engagement |
+| 4 | Baulke Dropout Phase | `BaulkeDropoutPhase` | `theories/baulke.py` | Baeulke et al. (2022) | 50 | — | Phase 2 |
+| 5 | Garrison CoI | `GarrisonCoI` | `theories/garrison_coi.py` | Garrison et al. (2000) | 20 | 700 | Phase 1 + Engagement |
+| 6 | Moore Transactional Distance | `MooreTransactionalDistance` | `theories/moore_td.py` | Moore (1993) | — | 600 | Engagement |
+| 7 | Epstein & Axtell Peer Influence | `EpsteinAxtellPeerInfluence` | `theories/epstein_axtell.py` | Epstein & Axtell (1996) | 40 | — | Phase 2 |
+| 8 | Rovai Persistence | `RovaiPersistence` | `theories/rovai.py` | Rovai (2003) | — | 400 | Engagement |
+| 9 | SDT Motivation Dynamics | `SDTMotivationDynamics` | `theories/sdt_motivation.py` | Deci & Ryan (1985) | 30 | 500 | Phase 1 + Engagement |
+| 10 | Gonzalez Exhaustion | `GonzalezExhaustion` | `theories/academic_exhaustion.py` | Gonzalez et al. (2025) | — | 800 | Phase 1 + Engagement |
+| 11 | Unavoidable Withdrawal | `UnavoidableWithdrawal` | `theories/unavoidable_withdrawal.py` | (life events) | — | — | Phase 1 (first check) |
+| -- | Positive Event Handler | `PositiveEventHandler` | `theories/positive_events.py` | (counter-pressure) | — | 300 | Engagement |
 
 > For academic citations and factor cluster tables, see `docs/THEORY.md`.
 
@@ -68,8 +73,8 @@ well-defined point in the weekly loop.
 | | Fields |
 |---|--------|
 | **Reads** | `StudentPersona.is_employed`, `.weekly_work_hours`, `.has_family_responsibilities`, `.financial_stress`, `.disability_severity`, `.self_regulation`, `.personality.conscientiousness` |
-| **Writes** | `SimulationState.coping_factor`, `SimulationState.env_shock_remaining`, `.env_shock_magnitude` (indirectly via engine) |
-| **When** | Engagement update -- `calculate_environmental_pressure()` and `update_coping()` called inside `_update_engagement()` |
+| **Writes** | `SimulationState.coping_factor`, `SimulationState.env_shock_remaining`, `.env_shock_magnitude` (shock state managed in `contribute_engagement_delta()`) |
+| **When** | Engagement update -- `contribute_engagement_delta()` dispatched at `_ENGAGEMENT_ORDER = 200` |
 
 **Key constants:**
 
@@ -101,7 +106,7 @@ well-defined point in the weekly loop.
 |---|--------|
 | **Reads** | `SimulationState.perceived_mastery`, `.perceived_mastery_count`, `.missed_assignments_streak`, `.coi_state` (all 3 presences), `.social_integration`; `StudentPersona.is_employed`, `.financial_stress`, `.has_family_responsibilities`; Moore avg TD |
 | **Writes** | `SimulationState.perceived_cost_benefit` |
-| **When** | Engagement update -- called when graded items submitted, exam weeks, or missed streak >= 2 |
+| **When** | Engagement update -- `contribute_engagement_delta()` dispatched at `_ENGAGEMENT_ORDER = 900`; conditional gate fires only on graded-item weeks, exam weeks, or missed streak >= 2 |
 
 **Key constants:**
 
@@ -179,7 +184,7 @@ See [dropout-mechanics.md](dropout-mechanics.md) for the full 6-phase state mach
 |---|--------|
 | **Reads** | `Course.structure_level`, `.dialogue_frequency`, `.instructor_responsiveness`; `StudentPersona.learner_autonomy`; `SimulationState.courses_active` |
 | **Writes** | None (returns a float consumed by engagement update and Kember) |
-| **When** | Engagement update -- `average()` called inside `_update_engagement()` and passed to `kember.recalculate()` |
+| **When** | Engagement update -- `contribute_engagement_delta()` dispatched at `_ENGAGEMENT_ORDER = 600` using pre-computed `ctx.avg_td`; result also passed to Kember |
 
 **Key constants:**
 
@@ -238,7 +243,7 @@ See [dropout-mechanics.md](dropout-mechanics.md) for the full 6-phase state mach
 |---|--------|
 | **Reads** | `StudentPersona.self_regulation`, `.goal_commitment`, `.self_efficacy`, `.learner_autonomy`, `.disability_severity`, `.institutional_support_access` |
 | **Writes** | None (returns floats consumed by engagement update) |
-| **When** | Engagement update -- `regulation_buffer()` and `engagement_floor()` called inside `_update_engagement()` |
+| **When** | Engagement update -- `contribute_engagement_delta()` dispatched at `_ENGAGEMENT_ORDER = 400` (regulation buffer); `engagement_floor()` remains an explicit engine call after the dispatch loop |
 
 **Key constants:**
 
@@ -370,11 +375,13 @@ via: `p_week = 1 - (1 - p_semester)^(1/N)`.
 
 **Source**: `theories/positive_events.py`
 
+`_ENGAGEMENT_ORDER = 300`. Implements `contribute_engagement_delta()` as of v1.6.0.
+
 | | Fields |
 |---|--------|
 | **Reads** | Week context (`positive_event` key) |
 | **Writes** | `SimulationState.social_integration`, `.perceived_cost_benefit`, `.coi_state.teaching_presence` |
-| **When** | Engagement update -- returns engagement boost, applies side effects directly |
+| **When** | Engagement update -- `contribute_engagement_delta()` dispatched at `_ENGAGEMENT_ORDER = 300`; side effects applied inside that method |
 
 **Defined events:**
 
@@ -468,13 +475,13 @@ graph LR
 
 - **Stateless classes, stateful constants**: Theory modules are stateless (no `self.xxx` state between calls), but their class-level `_UPPERCASE` constants are the tuning surface for Sobol/NSGA-II. Do not confuse the two.
 
-- **Call order matters for RNG**: Within Phase 1, the order is Tinto -> Garrison -> SDT -> Gonzalez -> Engagement update. Changing this order changes RNG consumption and breaks determinism.
+- **Call order matters for RNG**: Within Phase 1, the order is Tinto -> Garrison -> SDT -> Gonzalez -> Engagement update. Changing this order changes RNG consumption and breaks determinism. Within the engagement composition step, call order is controlled by `_ENGAGEMENT_ORDER` (100–900); altering those values changes RNG consumption in the same way.
 
 - **Moore returns, never writes**: `MooreTransactionalDistance` is the only module that never writes to `SimulationState`. It returns a float consumed by `_update_engagement()` and `kember.recalculate()`. This means its effect is always mediated.
 
 - **Epstein & Axtell fires in Phase 2**: Unlike all other modules, peer influence runs after all individual students have been processed. This is the Epstein & Axtell (1996) two-phase design -- individuals first, then social effects.
 
-- **Engagement update is not a module**: `_update_engagement()` lives in `engine.py`, not in `theories/`. It orchestrates calls to Bean & Metzner, Rovai, Moore, Kember, Gonzalez, and PositiveEventHandler. It is the most complex single method in the codebase.
+- **Engagement update is now protocol-dispatched**: Since v1.6.0, `_update_engagement()` in `engine.py` is a 27-line dispatch loop that calls `contribute_engagement_delta()` on each theory module in `_ENGAGEMENT_ORDER` sequence. Theory-specific delta logic lives in the theory modules themselves, not in the engine. `engagement_floor()` (Rovai) remains an explicit post-loop engine call.
 
 - **`perceived_mastery` vs `cumulative_gpa`**: Theory modules that need academic performance (Kember, SDT, Baulke) read `perceived_mastery` (raw quality, no floor), NOT `cumulative_gpa` (transcript GPA with floor). See [grading-and-gpa.md](grading-and-gpa.md).
 


### PR DESCRIPTION
## Summary
- 9-page developer wiki covering pipeline internals, simulation loop, engagement formula, theory modules, dropout mechanics, grading, calibration, and data export
- Updated to v1.6.0: engagement protocol unification (`contribute_engagement_delta`, `_ENGAGEMENT_ORDER`) reflected in engagement-formula.md and theory-modules.md
- Mermaid diagrams for engagement waterfall, theory interaction graph, pipeline stages
- README.md Documentation table gains Developer Wiki link

### Wiki Pages

| Page | Content |
|------|---------|
| `index.md` | Table of contents + glossary |
| `pipeline-walkthrough.md` | 6-stage pipeline with PipelineConfig |
| `simulation-loop.md` | Phase 1/2 architecture, TheoryModule Protocol |
| `engagement-formula.md` | 16-term decomposition with protocol dispatch architecture |
| `theory-modules.md` | 12 modules with `_PHASE_ORDER`/`_ENGAGEMENT_ORDER` columns |
| `dropout-mechanics.md` | Baulke 6-phase model + institutional modulation |
| `grading-and-gpa.md` | Dual-track GPA, GradingConfig, relative grading |
| `calibration-and-analysis.md` | Sobol + NSGA-II + OULAD validation |
| `data-export.md` | 4-table standard + 7-table OULAD export |

## Test plan
- [ ] All wiki links resolve correctly
- [ ] Mermaid diagrams render on GitHub
- [ ] CodeRabbit review
- [ ] doc_facts passes (no stale numbers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)