### PR TITLE
feat: Phase 2 UX polish — contrast, layout, interactions

### DIFF
--- a/synthed/dashboard/app.py
+++ b/synthed/dashboard/app.py
@@ -201,8 +201,8 @@ def server(input, output, session):
                 num_val = float(input[num_id]())
                 if abs(slider_val - num_val) > 0.001:
                     ui.update_numeric(num_id, value=slider_val)
-            except (ValueError, TypeError) as exc:
-                logger.debug("Sync slider->num skipped for %s: %s", slider_id, exc)
+            except (ValueError, TypeError):
+                pass
 
         @reactive.effect
         @reactive.event(input[num_id])
@@ -212,8 +212,8 @@ def server(input, output, session):
                 slider_val = float(input[slider_id]())
                 if abs(num_val - slider_val) > 0.001:
                     ui.update_slider(slider_id, value=num_val)
-            except (ValueError, TypeError) as exc:
-                logger.debug("Sync num->slider skipped for %s: %s", num_id, exc)
+            except (ValueError, TypeError):
+                pass
 
     for _sid, _nid in _sync_pairs:
         _make_sync(_sid, _nid)
@@ -224,7 +224,7 @@ def server(input, output, session):
             try:
                 total += float(input[f"{input_id}_{key}"]())
             except Exception:
-                logger.debug("Distribution sum: could not read %s_%s", input_id, key)
+                pass
         ok = abs(total - 1.0) <= 0.01
         color = "var(--success,#2DD4A0)" if ok else "var(--warning,#F5A623)"
         symbol = "\u2713" if ok else "\u2717"

--- a/synthed/dashboard/app.py
+++ b/synthed/dashboard/app.py
@@ -197,17 +197,23 @@ def server(input, output, session):
         @reactive.event(input[slider_id])
         def _sync_to_num():
             try:
-                ui.update_numeric(num_id, value=float(input[slider_id]()))
-            except Exception:
-                pass
+                slider_val = float(input[slider_id]())
+                num_val = float(input[num_id]())
+                if abs(slider_val - num_val) > 0.001:
+                    ui.update_numeric(num_id, value=slider_val)
+            except (ValueError, TypeError) as exc:
+                logger.debug("Sync slider->num skipped for %s: %s", slider_id, exc)
 
         @reactive.effect
         @reactive.event(input[num_id])
         def _sync_to_slider():
             try:
-                ui.update_slider(slider_id, value=float(input[num_id]()))
-            except Exception:
-                pass
+                num_val = float(input[num_id]())
+                slider_val = float(input[slider_id]())
+                if abs(num_val - slider_val) > 0.001:
+                    ui.update_slider(slider_id, value=num_val)
+            except (ValueError, TypeError) as exc:
+                logger.debug("Sync num->slider skipped for %s: %s", num_id, exc)
 
     for _sid, _nid in _sync_pairs:
         _make_sync(_sid, _nid)
@@ -217,8 +223,8 @@ def server(input, output, session):
         for key in keys:
             try:
                 total += float(input[f"{input_id}_{key}"]())
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("Distribution sum: could not read %s_%s: %s", input_id, key, exc)
         ok = abs(total - 1.0) <= 0.01
         color = "var(--success,#2DD4A0)" if ok else "var(--warning,#F5A623)"
         symbol = "\u2713" if ok else "\u2717"

--- a/synthed/dashboard/app.py
+++ b/synthed/dashboard/app.py
@@ -180,6 +180,27 @@ def server(input, output, session):
             editors.append(distribution_editor(f"persona_{field_name}", label, dist_val))
         return ui.div(*editors)
 
+    # ── Reactive distribution sum indicators ──
+    def _make_dist_sum_renderer(field_name: str, keys: list[str]):
+        input_id = f"persona_{field_name}"
+
+        @render.text(id=f"{input_id}_sum")
+        def _():
+            total = 0.0
+            for key in keys:
+                try:
+                    total += float(input[f"{input_id}_{key}"]())
+                except Exception:
+                    pass
+            ok = abs(total - 1.0) < 0.01
+            symbol = "\u2713" if ok else "\u2717"
+            return f"\u2211 = {total:.2f} {symbol}"
+
+    pc = default_config.persona_config
+    for _fn in DISTRIBUTION_FIELDS:
+        _dist_val = getattr(pc, _fn, {})
+        _make_dist_sum_renderer(_fn, list(_dist_val.keys()))
+
     # ── Simulation status indicator ──
     sim_running = reactive.value(False)
 

--- a/synthed/dashboard/app.py
+++ b/synthed/dashboard/app.py
@@ -223,8 +223,8 @@ def server(input, output, session):
         for key in keys:
             try:
                 total += float(input[f"{input_id}_{key}"]())
-            except Exception as exc:
-                logger.debug("Distribution sum: could not read %s_%s: %s", input_id, key, exc)
+            except Exception:
+                logger.debug("Distribution sum: could not read %s_%s", input_id, key)
         ok = abs(total - 1.0) <= 0.01
         color = "var(--success,#2DD4A0)" if ok else "var(--warning,#F5A623)"
         symbol = "\u2713" if ok else "\u2717"

--- a/synthed/dashboard/app.py
+++ b/synthed/dashboard/app.py
@@ -169,7 +169,13 @@ def server(input, output, session):
                             min=0.0, max=1.0, value=0.40, step=0.01),
         )
 
-    # ── Distribution editors ──
+    # ── Distribution editors + reactive sums ──
+    _pc = default_config.persona_config
+    _dist_registry = {
+        f"persona_{fn}": list(getattr(_pc, fn, {}).keys())
+        for fn in DISTRIBUTION_FIELDS
+    }
+
     @render.ui
     def distribution_editors():
         from .components.distribution_editor import distribution_editor
@@ -180,26 +186,75 @@ def server(input, output, session):
             editors.append(distribution_editor(f"persona_{field_name}", label, dist_val))
         return ui.div(*editors)
 
-    # ── Reactive distribution sum indicators ──
-    def _make_dist_sum_renderer(field_name: str, keys: list[str]):
-        input_id = f"persona_{field_name}"
+    # ── Sync slider <-> numeric for distributions ──
+    _sync_pairs: list[tuple[str, str]] = []
+    for _oid, _ks in _dist_registry.items():
+        for _k in _ks:
+            _sync_pairs.append((f"{_oid}_{_k}", f"{_oid}_{_k}_num"))
 
-        @render.text(id=f"{input_id}_sum")
-        def _():
-            total = 0.0
-            for key in keys:
-                try:
-                    total += float(input[f"{input_id}_{key}"]())
-                except Exception:
-                    pass
-            ok = abs(total - 1.0) < 0.01
-            symbol = "\u2713" if ok else "\u2717"
-            return f"\u2211 = {total:.2f} {symbol}"
+    def _make_sync(slider_id: str, num_id: str):
+        @reactive.effect
+        @reactive.event(input[slider_id])
+        def _sync_to_num():
+            try:
+                ui.update_numeric(num_id, value=float(input[slider_id]()))
+            except Exception:
+                pass
 
-    pc = default_config.persona_config
-    for _fn in DISTRIBUTION_FIELDS:
-        _dist_val = getattr(pc, _fn, {})
-        _make_dist_sum_renderer(_fn, list(_dist_val.keys()))
+        @reactive.effect
+        @reactive.event(input[num_id])
+        def _sync_to_slider():
+            try:
+                ui.update_slider(slider_id, value=float(input[num_id]()))
+            except Exception:
+                pass
+
+    for _sid, _nid in _sync_pairs:
+        _make_sync(_sid, _nid)
+
+    def _dist_sum_ui(input_id: str, keys: list[str]):
+        total = 0.0
+        for key in keys:
+            try:
+                total += float(input[f"{input_id}_{key}"]())
+            except Exception:
+                pass
+        ok = abs(total - 1.0) < 0.01
+        color = "var(--success,#2DD4A0)" if ok else "var(--warning,#F5A623)"
+        symbol = "\u2713" if ok else "\u2717"
+        return ui.div(
+            f"\u2211 = {total:.2f} {symbol}",
+            class_="text-end",
+            style=f"font-family:'JetBrains Mono',monospace;font-size:11px;color:{color};",
+        )
+
+    @render.ui
+    def persona_gender_distribution_sum():
+        return _dist_sum_ui("persona_gender_distribution", _dist_registry["persona_gender_distribution"])
+
+    @render.ui
+    def persona_motivation_levels_sum():
+        return _dist_sum_ui("persona_motivation_levels", _dist_registry["persona_motivation_levels"])
+
+    @render.ui
+    def persona_socioeconomic_distribution_sum():
+        return _dist_sum_ui("persona_socioeconomic_distribution", _dist_registry["persona_socioeconomic_distribution"])
+
+    @render.ui
+    def persona_prior_education_distribution_sum():
+        return _dist_sum_ui("persona_prior_education_distribution", _dist_registry["persona_prior_education_distribution"])
+
+    @render.ui
+    def persona_device_distribution_sum():
+        return _dist_sum_ui("persona_device_distribution", _dist_registry["persona_device_distribution"])
+
+    @render.ui
+    def persona_goal_orientation_distribution_sum():
+        return _dist_sum_ui("persona_goal_orientation_distribution", _dist_registry["persona_goal_orientation_distribution"])
+
+    @render.ui
+    def persona_learning_style_distribution_sum():
+        return _dist_sum_ui("persona_learning_style_distribution", _dist_registry["persona_learning_style_distribution"])
 
     # ── Simulation status indicator ──
     sim_running = reactive.value(False)
@@ -558,6 +613,16 @@ def server(input, output, session):
                     vals[key] = val
             except Exception:
                 pass
+
+        # Distribution dicts: read individual slider values
+        for input_id, keys in _dist_registry.items():
+            dist = {}
+            for sub_key in keys:
+                try:
+                    dist[sub_key] = float(input[f"{input_id}_{sub_key}"]())
+                except Exception:
+                    dist[sub_key] = vals.get(input_id, {}).get(sub_key, 0.0)
+            vals[input_id] = dist
 
         return vals
 

--- a/synthed/dashboard/app.py
+++ b/synthed/dashboard/app.py
@@ -124,7 +124,22 @@ def _approximate_weekly_dropouts(
 def server(input, output, session):
     # Reactive values
     sim_results = reactive.value(None)
+    active_preset = reactive.value("default")
     default_config = PipelineConfig()
+
+    # ── Preset buttons (reactive active state) ──
+    @render.ui
+    def preset_buttons_ui():
+        current = active_preset.get()
+        def _cls(name: str) -> str:
+            base = "btn preset-btn me-1"
+            return f"{base} btn-primary active" if name == current else f"{base} btn-outline-secondary"
+        return ui.div(
+            ui.input_action_button("preset_default", "Default", class_=_cls("default")),
+            ui.input_action_button("preset_high_risk", "High Risk", class_=_cls("high_risk")),
+            ui.input_action_button("preset_low_dropout", "Low Dropout", class_=_cls("low_dropout")),
+            class_="d-flex",
+        )
 
     # ── Status text ──
     @render.text
@@ -485,16 +500,19 @@ def server(input, output, session):
     @reactive.effect
     @reactive.event(input.preset_default)
     def _preset_default():
+        active_preset.set("default")
         _apply_preset("default")
 
     @reactive.effect
     @reactive.event(input.preset_high_risk)
     def _preset_high_risk():
+        active_preset.set("high_risk")
         _apply_preset("high_risk")
 
     @reactive.effect
     @reactive.event(input.preset_low_dropout)
     def _preset_low_dropout():
+        active_preset.set("low_dropout")
         _apply_preset("low_dropout")
 
     # ── Helper: collect current UI values ──

--- a/synthed/dashboard/app.py
+++ b/synthed/dashboard/app.py
@@ -219,7 +219,7 @@ def server(input, output, session):
                 total += float(input[f"{input_id}_{key}"]())
             except Exception:
                 pass
-        ok = abs(total - 1.0) < 0.01
+        ok = abs(total - 1.0) <= 0.01
         color = "var(--success,#2DD4A0)" if ok else "var(--warning,#F5A623)"
         symbol = "\u2713" if ok else "\u2717"
         return ui.div(

--- a/synthed/dashboard/charts.py
+++ b/synthed/dashboard/charts.py
@@ -50,8 +50,8 @@ def dropout_timeline(weekly_dropouts: list[int], n_students: int) -> go.Figure:
     fig.add_trace(go.Scatter(
         x=weeks, y=cumulative,
         mode="lines+markers",
-        line=dict(color=ACCENT, width=2),
-        marker=dict(size=5, color=ACCENT),
+        line=dict(color=ACCENT, width=3),
+        marker=dict(size=7, color=ACCENT),
         name="Cumulative Dropout %",
         hovertemplate="Week %{x}: %{y:.1f}%<extra></extra>",
     ))

--- a/synthed/dashboard/components/distribution_editor.py
+++ b/synthed/dashboard/components/distribution_editor.py
@@ -8,7 +8,7 @@ from shiny import ui
 def distribution_editor(input_id: str, label: str, values: dict[str, float]) -> ui.Tag:
     """Render a distribution editor with sliders that must sum to 1.0.
 
-    Each key gets a slider [0, 1]. Sum indicator is reactive (rendered server-side).
+    Sum indicator is rendered via output_ui (reactive, server-side).
     """
     sliders = []
     for key, val in values.items():
@@ -16,11 +16,14 @@ def distribution_editor(input_id: str, label: str, values: dict[str, float]) -> 
         sliders.append(
             ui.div(
                 ui.row(
-                    ui.column(4, ui.tags.label(key, class_="text-secondary",
-                                               style="font-size:12px;")),
-                    ui.column(8, ui.input_slider(slider_id, None, min=0.0, max=1.0,
+                    ui.column(5, ui.tags.label(key, class_="text-secondary",
+                                               style="font-size:12px;line-height:32px;")),
+                    ui.column(4, ui.input_slider(slider_id, None, min=0.0, max=1.0,
                                                  value=round(val, 2), step=0.01,
                                                  width="100%")),
+                    ui.column(3, ui.input_numeric(f"{slider_id}_num", None,
+                                                  value=round(val, 2), min=0.0, max=1.0,
+                                                  step=0.01, width="100%")),
                 ),
                 class_="mb-1",
             )
@@ -29,7 +32,7 @@ def distribution_editor(input_id: str, label: str, values: dict[str, float]) -> 
     return ui.div(
         ui.tags.label(label, class_="text-secondary fw-bold", style="font-size:12px;"),
         *sliders,
-        ui.output_text(f"{input_id}_sum", inline=True),
+        ui.output_ui(f"{input_id}_sum"),
         class_="mb-3 p-2",
         style="background:var(--bg, #0F1117);border-radius:6px;",
     )

--- a/synthed/dashboard/components/distribution_editor.py
+++ b/synthed/dashboard/components/distribution_editor.py
@@ -8,8 +8,7 @@ from shiny import ui
 def distribution_editor(input_id: str, label: str, values: dict[str, float]) -> ui.Tag:
     """Render a distribution editor with sliders that must sum to 1.0.
 
-    Each key gets a slider [0, 1]. Sum indicator shown as static text
-    (actual sum validation is handled server-side via config_bridge.normalize_distribution).
+    Each key gets a slider [0, 1]. Sum indicator is reactive (rendered server-side).
     """
     sliders = []
     for key, val in values.items():
@@ -27,19 +26,10 @@ def distribution_editor(input_id: str, label: str, values: dict[str, float]) -> 
             )
         )
 
-    # Static sum indicator — reactive update deferred to Phase 2
-    total = round(sum(values.values()), 2)
-    sum_indicator = ui.div(
-        f"\u2211 = {total:.2f} \u2713" if abs(total - 1.0) < 0.01 else f"\u2211 = {total:.2f} \u2717",
-        class_="text-end",
-        style=f"font-family:'JetBrains Mono',monospace;font-size:11px;"
-              f"color:{'var(--success,#2DD4A0)' if abs(total - 1.0) < 0.01 else 'var(--warning,#F5A623)'};",
-    )
-
     return ui.div(
         ui.tags.label(label, class_="text-secondary fw-bold", style="font-size:12px;"),
         *sliders,
-        sum_indicator,
+        ui.output_text(f"{input_id}_sum", inline=True),
         class_="mb-3 p-2",
         style="background:var(--bg, #0F1117);border-radius:6px;",
     )

--- a/synthed/dashboard/components/param_panel.py
+++ b/synthed/dashboard/components/param_panel.py
@@ -70,6 +70,14 @@ def pipeline_controls() -> ui.Tag:
             ui.column(6, ui.input_checkbox("export_oulad", "Export OULAD Format", value=False)),
             ui.column(6, ui.input_text("output_dir", "Output Directory", value="./output")),
         ),
+        ui.hr(style="border-color:var(--border,#1E2130);margin:8px 0;"),
+        ui.row(
+            ui.column(6, ui.download_button("export_config", "Export Config",
+                                            class_="btn btn-outline-secondary btn-sm w-100")),
+            ui.column(6, ui.input_file("import_config", "Import",
+                                       accept=[".json"], button_label="Import",
+                                       width="100%")),
+        ),
         value="pipeline",
         icon=ui.tags.i(class_="bi bi-gear"),
     )
@@ -135,14 +143,12 @@ def grading_config_panel() -> ui.Tag:
     return ui.accordion_panel(
         "Grading",
         # Modes
-        ui.row(
-            ui.column(4, ui.input_select("grading_assessment_mode", "Assessment Mode",
-                                         {"mixed": "Mixed", "exam_only": "Exam Only", "continuous": "Continuous"})),
-            ui.column(4, ui.input_select("grading_grading_method", "Grading Method",
-                                         {"absolute": "Absolute", "relative": "Relative"})),
-            ui.column(4, ui.input_select("grading_distribution", "Distribution",
-                                         {"beta": "Beta", "normal": "Normal", "uniform": "Uniform"})),
-        ),
+        ui.input_select("grading_assessment_mode", "Assessment Mode",
+                        {"mixed": "Mixed", "exam_only": "Exam Only", "continuous": "Continuous"}),
+        ui.input_select("grading_grading_method", "Grading Method",
+                        {"absolute": "Absolute", "relative": "Relative"}),
+        ui.input_select("grading_distribution", "Distribution",
+                        {"beta": "Beta", "normal": "Normal", "uniform": "Uniform"}),
         # Weights
         ui.h6("Weights", class_="text-secondary mt-3"),
         _slider_input("grading_midterm_weight", "midterm_weight", 0.40),
@@ -254,24 +260,17 @@ def engine_config_offcanvas() -> ui.Tag:
                 tabindex="-1",
                 id="engine_offcanvas",
                 style="width:450px;background:var(--bg,#0F1117);color:var(--text-primary,#E8EAF0);",
+                **{"data-bs-backdrop": "true"},
             ),
         ),
     )
 
 
 def preset_buttons() -> ui.Tag:
-    """Preset configuration buttons."""
+    """Preset configuration buttons with active state via output_ui."""
     return ui.div(
         ui.h6("Presets", class_="text-secondary mb-2"),
-        ui.div(
-            ui.input_action_button("preset_default", "Default",
-                                   class_="btn btn-outline-secondary preset-btn me-1"),
-            ui.input_action_button("preset_high_risk", "High Risk",
-                                   class_="btn btn-outline-secondary preset-btn me-1"),
-            ui.input_action_button("preset_low_dropout", "Low Dropout",
-                                   class_="btn btn-outline-secondary preset-btn"),
-            class_="d-flex",
-        ),
+        ui.output_ui("preset_buttons_ui"),
         class_="mb-3",
     )
 

--- a/synthed/dashboard/components/results_panel.py
+++ b/synthed/dashboard/components/results_panel.py
@@ -45,27 +45,27 @@ def results_layout() -> ui.Tag:
             ui.output_ui("chart_dropout"),
             class_="mb-3",
         ),
-        ui.div(
-            ui.h6("Engagement Distribution"),
-            ui.output_ui("chart_engagement"),
-            class_="mb-3",
-        ),
-        ui.div(
-            ui.h6("GPA Distribution"),
-            ui.output_ui("chart_gpa"),
-            class_="mb-3",
+        ui.row(
+            ui.column(
+                6,
+                ui.div(
+                    ui.h6("Engagement Distribution"),
+                    ui.output_ui("chart_engagement"),
+                    class_="mb-3",
+                ),
+            ),
+            ui.column(
+                6,
+                ui.div(
+                    ui.h6("GPA Distribution"),
+                    ui.output_ui("chart_gpa"),
+                    class_="mb-3",
+                ),
+            ),
         ),
         ui.div(
             ui.h6("Validation Radar"),
             ui.output_ui("chart_validation"),
             class_="mb-3",
-        ),
-        # Export
-        ui.hr(class_="my-3", style="border-color:var(--border,#1E2130);"),
-        ui.row(
-            ui.column(6, ui.download_button("export_config", "Export Config JSON",
-                                            class_="btn btn-outline-secondary btn-sm w-100")),
-            ui.column(6, ui.input_file("import_config", "Import configuration",
-                                       accept=[".json"], button_label="Import Config")),
         ),
     )

--- a/synthed/dashboard/components/warnings.py
+++ b/synthed/dashboard/components/warnings.py
@@ -52,6 +52,19 @@ def validate_config(values: dict[str, Any]) -> list[dict[str, str]]:
             "level": "error",
         })
 
+    # Distribution sums must equal 1.0
+    from ..config_bridge import DISTRIBUTION_FIELDS
+    for field_name, label in DISTRIBUTION_FIELDS.items():
+        dist = values.get(f"persona_{field_name}")
+        if isinstance(dist, dict) and dist:
+            total = sum(dist.values())
+            if abs(total - 1.0) > 0.01:
+                issues.append({
+                    "field": label,
+                    "message": f"{label} distribution sums to {total:.2f} (must be 1.0)",
+                    "level": "error",
+                })
+
     return issues
 
 

--- a/synthed/dashboard/theme.py
+++ b/synthed/dashboard/theme.py
@@ -104,6 +104,10 @@ body {
     font-weight: 500;
 }
 
+/* Heading contrast fix — WCAG AA min 4.5:1 */
+h5, .h5 { color: #A0A5B4 !important; }
+h6, .h6 { color: #8B90A0 !important; }
+
 /* Sliders */
 .irs--shiny .irs-bar { background: var(--accent); }
 .irs--shiny .irs-handle { border-color: var(--accent); background: var(--accent); }
@@ -205,6 +209,34 @@ body {
     font-size: 12px;
     padding: 4px 12px;
 }
+.preset-btn.active {
+    background: var(--accent) !important;
+    border-color: var(--accent) !important;
+    color: #fff !important;
+}
+
+/* Card value contrast fix */
+.card-value.text-primary { color: #3CA0E6 !important; }
+.card-value.text-warning { color: #F5A623 !important; }
+.card-value.text-success { color: #2DD4A0 !important; }
+
+/* Import file input placeholder fix */
+.shiny-input-container .form-control::file-selector-button {
+    color: var(--text-secondary) !important;
+}
+
+/* Select dropdown min-width */
+.form-select { min-width: 100px; }
+
+/* Sidebar scroll fix — ensure independent scroll */
+.bslib-sidebar-layout > .sidebar,
+.bslib-sidebar-layout > .sidebar > .sidebar-content {
+    overflow-y: auto !important;
+    max-height: calc(100vh - 56px) !important;
+}
+
+/* Offcanvas backdrop */
+.offcanvas-backdrop { background-color: rgba(0,0,0,0.6); }
 """
 
 # Combine generated :root with static CSS


### PR DESCRIPTION
## Summary
- **WCAG contrast fixes**: h5/h6 headings bumped to 4.5:1+ ratio, card values to #3CA0E6
- **Layout**: dropdowns stacked (fix truncation), Engagement+GPA charts 2-column grid, Export/Import moved to Pipeline Controls
- **Interaction**: preset active state highlight, offcanvas backdrop, thicker chart lines
- **Distribution validation**: reactive sum indicator, sum != 1.0 blocks simulation, numeric steppers with bidirectional sync

## Test plan
- [x] `ruff check` clean
- [x] `pytest tests/test_dashboard.py` — 42 passed
- [x] Visual verification in browser
- [x] CodeRabbit review — all findings addressed

Addresses UX audit findings from Phase 2 backlog.