### PR TITLE
feat: Phase 3 visual redesign — indigo palette, glassmorphism, semantic cards

### DIFF
--- a/synthed/dashboard/app.py
+++ b/synthed/dashboard/app.py
@@ -44,6 +44,21 @@ app_ui = ui.page_navbar(
             href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css",
         ),
         ui.tags.script(src="https://cdn.plot.ly/plotly-2.35.0.min.js"),
+        ui.tags.script(
+            """
+            $(function() {
+                $(document).on('click', '#toggle_theme', function() {
+                    document.body.classList.toggle('light-mode');
+                    var icon = document.getElementById('theme_icon');
+                    if (document.body.classList.contains('light-mode')) {
+                        icon.className = 'bi bi-moon-fill';
+                    } else {
+                        icon.className = 'bi bi-sun-fill';
+                    }
+                });
+            });
+            """
+        ),
     ),
     ui.nav_panel(
         "Configure",
@@ -84,6 +99,15 @@ app_ui = ui.page_navbar(
                 # Results area (shown after simulation)
                 ui.output_ui("results_area"),
             ),
+        ),
+    ),
+    ui.nav_spacer(),
+    ui.nav_control(
+        ui.input_action_button(
+            "toggle_theme",
+            ui.tags.i(class_="bi bi-sun-fill", id="theme_icon"),
+            class_="btn btn-link text-secondary",
+            style="font-size:18px;text-decoration:none;",
         ),
     ),
     title=ui.span(
@@ -411,6 +435,35 @@ def server(input, output, session):
         passed = sum(1 for r in results if isinstance(r, dict) and r.get("passed"))
         return f"{passed}/{len(results)} passed"
 
+    # ── Chart settings helper ──
+    def _get_chart_settings() -> charts.ChartSettings:
+        def _val(key, default):
+            try:
+                v = input[key]()
+                return v if v is not None else default
+            except Exception:
+                return default
+
+        return charts.ChartSettings(
+            bins=int(_val("chart_bins", 30)),
+            bar_opacity=float(_val("chart_bar_opacity", 0.8)),
+            bar_edge=bool(_val("chart_bar_edge", True)),
+            bar_edge_width=float(_val("chart_bar_edge_width", 1.0)),
+            show_mean=bool(_val("chart_show_mean", True)),
+            show_median=bool(_val("chart_show_median", True)),
+            show_pass_line=bool(_val("chart_show_pass_line", True)),
+            show_dist_line=bool(_val("chart_show_dist_line", True)),
+            show_legend=bool(_val("chart_show_legend", False)),
+            line_width=int(_val("chart_line_width", 3)),
+            marker_size=int(_val("chart_marker_size", 7)),
+            eng_x_label=str(_val("chart_eng_x_label", "Final Engagement")),
+            eng_y_label=str(_val("chart_eng_y_label", "Count")),
+            gpa_x_label=str(_val("chart_gpa_x_label", "Cumulative GPA")),
+            gpa_y_label=str(_val("chart_gpa_y_label", "Count")),
+            dropout_x_label=str(_val("chart_dropout_x_label", "Week")),
+            dropout_y_label=str(_val("chart_dropout_y_label", "Cumulative Dropout %")),
+        )
+
     # ── Chart renders ──
     @render.ui
     def chart_dropout():
@@ -428,7 +481,7 @@ def server(input, output, session):
         weekly = _approximate_weekly_dropouts(
             dropout_count, mean_week, std_week, total_weeks,
         )
-        fig = charts.dropout_timeline(weekly, n)
+        fig = charts.dropout_timeline(weekly, n, settings=_get_chart_settings())
         return ui.HTML(fig.to_html(full_html=False, include_plotlyjs=False))
 
     @render.ui
@@ -445,7 +498,7 @@ def server(input, output, session):
         # Approximate distribution from summary stats
         rng = np.random.default_rng(0)
         engagements = np.clip(rng.normal(mean_eng, max(std_eng, 0.01), n), 0.01, 0.99).tolist()
-        fig = charts.engagement_distribution(engagements)
+        fig = charts.engagement_distribution(engagements, settings=_get_chart_settings())
         return ui.HTML(fig.to_html(full_html=False, include_plotlyjs=False))
 
     @render.ui
@@ -471,7 +524,7 @@ def server(input, output, session):
             dist_t = input.grading_distinction_threshold()
         except (KeyError, TypeError):
             logger.debug("GPA chart: using default thresholds (inputs not yet available)")
-        fig = charts.gpa_distribution(gpas, pass_t * gpa_scale, dist_t * gpa_scale)
+        fig = charts.gpa_distribution(gpas, pass_t * gpa_scale, dist_t * gpa_scale, settings=_get_chart_settings())
         return ui.HTML(fig.to_html(full_html=False, include_plotlyjs=False))
 
     @render.ui

--- a/synthed/dashboard/app.py
+++ b/synthed/dashboard/app.py
@@ -80,15 +80,29 @@ app_ui = ui.page_navbar(
                         }
                     });
                 }
-                $(document).on('click', '#toggle_theme', function() {
-                    document.body.classList.toggle('light-mode');
-                    var isLight = document.body.classList.contains('light-mode');
-                    this.setAttribute('aria-pressed', isLight ? 'true' : 'false');
-                    this.setAttribute('aria-label',
-                        isLight ? 'Switch to dark mode' : 'Switch to light mode');
+                function applyTheme(isLight) {
+                    document.body.classList.toggle('light-mode', isLight);
+                    var btn = document.getElementById('toggle_theme');
+                    if (btn) {
+                        btn.setAttribute('aria-pressed', isLight ? 'true' : 'false');
+                        btn.setAttribute('aria-label',
+                            isLight ? 'Switch to dark mode' : 'Switch to light mode');
+                    }
                     var icon = document.getElementById('theme_icon');
-                    icon.className = isLight ? 'bi bi-moon-fill' : 'bi bi-sun-fill';
+                    if (icon) icon.className = isLight ? 'bi bi-moon-fill' : 'bi bi-sun-fill';
                     restyleCharts(isLight ? lightChart : darkChart);
+                }
+                // Restore saved preference or follow system
+                var saved = localStorage.getItem('synthed-theme');
+                if (saved === 'light') {
+                    applyTheme(true);
+                } else if (!saved && window.matchMedia('(prefers-color-scheme: light)').matches) {
+                    applyTheme(true);
+                }
+                $(document).on('click', '#toggle_theme', function() {
+                    var isLight = !document.body.classList.contains('light-mode');
+                    localStorage.setItem('synthed-theme', isLight ? 'light' : 'dark');
+                    applyTheme(isLight);
                 });
             });
             """

--- a/synthed/dashboard/app.py
+++ b/synthed/dashboard/app.py
@@ -47,14 +47,48 @@ app_ui = ui.page_navbar(
         ui.tags.script(
             """
             $(function() {
+                var darkChart = {
+                    font: '#94A3B8', grid: 'rgba(30,33,48,0.5)',
+                    hoverBg: '#1A1D27', hoverFont: '#F1F5F9', hoverBorder: '#1E2130',
+                    surface: '#1A1D27', border: '#1E2130'
+                };
+                var lightChart = {
+                    font: '#475569', grid: 'rgba(226,232,240,0.5)',
+                    hoverBg: '#FFFFFF', hoverFont: '#0F172A', hoverBorder: '#E2E8F0',
+                    surface: '#FFFFFF', border: '#E2E8F0'
+                };
+                function restyleCharts(c) {
+                    document.querySelectorAll('.js-plotly-plot').forEach(function(el) {
+                        Plotly.relayout(el, {
+                            'font.color': c.font,
+                            'xaxis.gridcolor': c.grid, 'xaxis.zerolinecolor': c.grid,
+                            'yaxis.gridcolor': c.grid, 'yaxis.zerolinecolor': c.grid,
+                            'hoverlabel.bgcolor': c.hoverBg,
+                            'hoverlabel.font.color': c.hoverFont,
+                            'hoverlabel.bordercolor': c.hoverBorder,
+                            'polar.bgcolor': c.surface,
+                            'polar.radialaxis.gridcolor': c.border,
+                            'polar.radialaxis.linecolor': c.border,
+                            'polar.angularaxis.gridcolor': c.border,
+                            'polar.angularaxis.linecolor': c.border
+                        });
+                        var data = el.data || [];
+                        for (var i = 0; i < data.length; i++) {
+                            if (data[i].type === 'histogram') {
+                                Plotly.restyle(el, {'marker.line.color': c.surface}, [i]);
+                            }
+                        }
+                    });
+                }
                 $(document).on('click', '#toggle_theme', function() {
                     document.body.classList.toggle('light-mode');
+                    var isLight = document.body.classList.contains('light-mode');
+                    this.setAttribute('aria-pressed', isLight ? 'true' : 'false');
+                    this.setAttribute('aria-label',
+                        isLight ? 'Switch to dark mode' : 'Switch to light mode');
                     var icon = document.getElementById('theme_icon');
-                    if (document.body.classList.contains('light-mode')) {
-                        icon.className = 'bi bi-moon-fill';
-                    } else {
-                        icon.className = 'bi bi-sun-fill';
-                    }
+                    icon.className = isLight ? 'bi bi-moon-fill' : 'bi bi-sun-fill';
+                    restyleCharts(isLight ? lightChart : darkChart);
                 });
             });
             """
@@ -108,6 +142,8 @@ app_ui = ui.page_navbar(
             ui.tags.i(class_="bi bi-sun-fill", id="theme_icon"),
             class_="btn btn-link text-secondary",
             style="font-size:18px;text-decoration:none;",
+            title="Toggle theme",
+            **{"aria-label": "Switch to light mode", "aria-pressed": "false"},
         ),
     ),
     title=ui.span(

--- a/synthed/dashboard/charts.py
+++ b/synthed/dashboard/charts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 import plotly.graph_objects as go
@@ -10,6 +11,29 @@ from .theme import (
     SURFACE, BORDER, TEXT_PRIMARY, TEXT_SECONDARY, TEXT_MUTED,
     ACCENT, ACCENT_LIGHT, SUCCESS, WARNING, ERROR, INFO,
 )
+
+
+@dataclass(frozen=True)
+class ChartSettings:
+    """User-configurable chart appearance settings."""
+
+    bins: int = 30
+    bar_opacity: float = 0.8
+    bar_edge: bool = True
+    bar_edge_width: float = 1.0
+    show_mean: bool = True
+    show_median: bool = True
+    show_pass_line: bool = True
+    show_dist_line: bool = True
+    show_legend: bool = False
+    line_width: int = 3
+    marker_size: int = 7
+    eng_x_label: str = "Final Engagement"
+    eng_y_label: str = "Count"
+    gpa_x_label: str = "Cumulative GPA"
+    gpa_y_label: str = "Count"
+    dropout_x_label: str = "Week"
+    dropout_y_label: str = "Cumulative Dropout %"
 
 _GRID_COLOR = "rgba(30, 33, 48, 0.5)"
 
@@ -22,6 +46,7 @@ _LAYOUT_DEFAULTS = dict(
     yaxis=dict(gridcolor=_GRID_COLOR, zerolinecolor=_GRID_COLOR),
     hoverlabel=dict(bgcolor=SURFACE, font_color=TEXT_PRIMARY, bordercolor=BORDER),
     colorway=[ACCENT, ACCENT_LIGHT, SUCCESS, WARNING, ERROR, INFO],
+    height=400,
 )
 
 
@@ -31,14 +56,19 @@ def _base_layout(**overrides: Any) -> dict:
     return layout
 
 
-def dropout_timeline(weekly_dropouts: list[int], n_students: int) -> go.Figure:
+def dropout_timeline(
+    weekly_dropouts: list[int],
+    n_students: int,
+    settings: ChartSettings | None = None,
+) -> go.Figure:
     """Cumulative dropout percentage by week — line chart."""
+    s = settings or ChartSettings()
     if n_students <= 0 or not weekly_dropouts:
         fig = go.Figure()
         fig.update_layout(**_base_layout(
-            xaxis_title="Week",
-            yaxis_title="Cumulative Dropout %",
-            showlegend=False,
+            xaxis_title=s.dropout_x_label,
+            yaxis_title=s.dropout_y_label,
+            showlegend=s.show_legend,
         ))
         fig.add_annotation(
             text="No dropout data", showarrow=False,
@@ -52,16 +82,16 @@ def dropout_timeline(weekly_dropouts: list[int], n_students: int) -> go.Figure:
     fig.add_trace(go.Scatter(
         x=weeks, y=cumulative,
         mode="lines+markers",
-        line=dict(color=ACCENT, width=3),
-        marker=dict(size=7, color=ACCENT),
+        line=dict(color=ACCENT, width=s.line_width),
+        marker=dict(size=s.marker_size, color=ACCENT),
         name="Cumulative Dropout %",
         hovertemplate="Week %{x}: %{y:.1f}%<extra></extra>",
     ))
     fig.update_layout(**_base_layout(
-        xaxis_title="Week",
-        yaxis_title="Cumulative Dropout %",
+        xaxis_title=s.dropout_x_label,
+        yaxis_title=s.dropout_y_label,
         yaxis_range=[0, max(cumulative[-1] * 1.15, 10) if cumulative else 100],
-        showlegend=False,
+        showlegend=s.show_legend,
     ))
     return fig
 
@@ -76,30 +106,45 @@ def _cumulative_percentages(weekly: list[int], n_students: int) -> list[float]:
     return result
 
 
-def engagement_distribution(engagements: list[float]) -> go.Figure:
+def engagement_distribution(
+    engagements: list[float],
+    settings: ChartSettings | None = None,
+) -> go.Figure:
     """Final engagement histogram with mean/median markers."""
     import numpy as np
 
+    s = settings or ChartSettings()
     mean_val = float(np.mean(engagements))
     median_val = float(np.median(engagements))
+
+    edge_kwargs: dict[str, Any] = {}
+    if s.bar_edge:
+        edge_kwargs = dict(marker_line_color=SURFACE, marker_line_width=s.bar_edge_width)
 
     fig = go.Figure()
     fig.add_trace(go.Histogram(
         x=engagements,
-        nbinsx=30,
+        nbinsx=s.bins,
         marker_color=ACCENT,
-        opacity=0.8,
+        opacity=s.bar_opacity,
         name="Engagement",
         hovertemplate="Range: %{x}<br>Count: %{y}<extra></extra>",
+        **edge_kwargs,
     ))
-    fig.add_vline(x=mean_val, line_dash="dash", line_color=WARNING,
-                  annotation_text=f"Mean: {mean_val:.3f}", annotation_font_color=WARNING)
-    fig.add_vline(x=median_val, line_dash="dot", line_color=SUCCESS,
-                  annotation_text=f"Median: {median_val:.3f}", annotation_font_color=SUCCESS)
+    if s.show_mean:
+        fig.add_vline(x=mean_val, line_dash="dash", line_color=WARNING,
+                      annotation_text=f"Mean: {mean_val:.3f}",
+                      annotation_font_color=WARNING,
+                      annotation_yshift=10)
+    if s.show_median:
+        fig.add_vline(x=median_val, line_dash="dot", line_color=SUCCESS,
+                      annotation_text=f"Median: {median_val:.3f}",
+                      annotation_font_color=SUCCESS,
+                      annotation_yshift=-10)
     fig.update_layout(**_base_layout(
-        xaxis_title="Final Engagement",
-        yaxis_title="Count",
-        showlegend=False,
+        xaxis_title=s.eng_x_label,
+        yaxis_title=s.eng_y_label,
+        showlegend=s.show_legend,
     ))
     return fig
 
@@ -108,25 +153,39 @@ def gpa_distribution(
     gpas: list[float],
     pass_threshold: float = 0.64,
     distinction_threshold: float = 0.73,
+    settings: ChartSettings | None = None,
 ) -> go.Figure:
     """GPA distribution histogram with pass/distinction threshold lines."""
+    s = settings or ChartSettings()
+
+    edge_kwargs: dict[str, Any] = {}
+    if s.bar_edge:
+        edge_kwargs = dict(marker_line_color=SURFACE, marker_line_width=s.bar_edge_width)
+
     fig = go.Figure()
     fig.add_trace(go.Histogram(
         x=gpas,
-        nbinsx=25,
+        nbinsx=s.bins,
         marker_color=SUCCESS,
-        opacity=0.8,
+        opacity=s.bar_opacity,
         name="GPA",
         hovertemplate="GPA: %{x:.2f}<br>Count: %{y}<extra></extra>",
+        **edge_kwargs,
     ))
-    fig.add_vline(x=pass_threshold, line_dash="dash", line_color=WARNING,
-                  annotation_text=f"Pass: {pass_threshold:.2f}", annotation_font_color=WARNING)
-    fig.add_vline(x=distinction_threshold, line_dash="dash", line_color=ACCENT,
-                  annotation_text=f"Distinction: {distinction_threshold:.2f}", annotation_font_color=ACCENT)
+    if s.show_pass_line:
+        fig.add_vline(x=pass_threshold, line_dash="dash", line_color=WARNING,
+                      annotation_text=f"Pass: {pass_threshold:.2f}",
+                      annotation_font_color=WARNING,
+                      annotation_yshift=10)
+    if s.show_dist_line:
+        fig.add_vline(x=distinction_threshold, line_dash="dash", line_color=ACCENT,
+                      annotation_text=f"Distinction: {distinction_threshold:.2f}",
+                      annotation_font_color=ACCENT,
+                      annotation_yshift=-10)
     fig.update_layout(**_base_layout(
-        xaxis_title="Cumulative GPA",
-        yaxis_title="Count",
-        showlegend=False,
+        xaxis_title=s.gpa_x_label,
+        yaxis_title=s.gpa_y_label,
+        showlegend=s.show_legend,
     ))
     return fig
 

--- a/synthed/dashboard/charts.py
+++ b/synthed/dashboard/charts.py
@@ -7,19 +7,21 @@ from typing import Any
 import plotly.graph_objects as go
 
 from .theme import (
-    BG, SURFACE, BORDER, TEXT_PRIMARY, TEXT_SECONDARY, TEXT_MUTED,
-    ACCENT, SUCCESS, WARNING,
+    SURFACE, BORDER, TEXT_PRIMARY, TEXT_SECONDARY, TEXT_MUTED,
+    ACCENT, ACCENT_LIGHT, SUCCESS, WARNING, ERROR, INFO,
 )
 
+_GRID_COLOR = "rgba(30, 33, 48, 0.5)"
 
 _LAYOUT_DEFAULTS = dict(
-    paper_bgcolor=BG,
-    plot_bgcolor=SURFACE,
+    paper_bgcolor="rgba(0,0,0,0)",
+    plot_bgcolor="rgba(0,0,0,0)",
     font=dict(family="Inter, system-ui, sans-serif", color=TEXT_SECONDARY, size=12),
     margin=dict(l=40, r=20, t=30, b=40),
-    xaxis=dict(gridcolor=BORDER, zerolinecolor=BORDER),
-    yaxis=dict(gridcolor=BORDER, zerolinecolor=BORDER),
+    xaxis=dict(gridcolor=_GRID_COLOR, zerolinecolor=_GRID_COLOR),
+    yaxis=dict(gridcolor=_GRID_COLOR, zerolinecolor=_GRID_COLOR),
     hoverlabel=dict(bgcolor=SURFACE, font_color=TEXT_PRIMARY, bordercolor=BORDER),
+    colorway=[ACCENT, ACCENT_LIGHT, SUCCESS, WARNING, ERROR, INFO],
 )
 
 
@@ -142,7 +144,7 @@ def validation_radar(level_scores: dict[str, float]) -> go.Figure:
         r=values_closed,
         theta=categories_closed,
         fill="toself",
-        fillcolor="rgba(79, 142, 247, 0.15)",
+        fillcolor="rgba(99, 102, 241, 0.15)",
         line=dict(color=ACCENT, width=2),
         marker=dict(size=6, color=ACCENT),
         name="Validation Score",

--- a/synthed/dashboard/components/results_panel.py
+++ b/synthed/dashboard/components/results_panel.py
@@ -36,10 +36,78 @@ def summary_cards_row() -> ui.Tag:
     )
 
 
+def _chart_settings_offcanvas() -> ui.Tag:
+    """Offcanvas panel with chart customization controls."""
+    return ui.TagList(
+        ui.tags.button(
+            ui.tags.i(class_="bi bi-gear me-1"),
+            "Chart Settings",
+            type="button",
+            class_="btn btn-outline-secondary btn-sm",
+            **{"data-bs-toggle": "offcanvas", "data-bs-target": "#chart_settings"},
+        ),
+        ui.tags.div(
+            ui.tags.div(
+                ui.tags.div(
+                    ui.tags.h5("Chart Settings", class_="offcanvas-title"),
+                    ui.tags.button(
+                        type="button", class_="btn-close btn-close-white",
+                        **{"data-bs-dismiss": "offcanvas"},
+                    ),
+                    class_="offcanvas-header",
+                ),
+                ui.tags.div(
+                    # Histogram settings
+                    ui.h6("Histograms"),
+                    ui.input_slider("chart_bins", "Bin Count", min=5, max=50, value=30, step=1),
+                    ui.input_slider("chart_bar_opacity", "Bar Opacity", min=0.3, max=1.0, value=0.8, step=0.05),
+                    ui.input_checkbox("chart_bar_edge", "Bar Edge", value=True),
+                    ui.input_slider("chart_bar_edge_width", "Edge Width", min=0.5, max=3.0, value=1.0, step=0.5),
+                    ui.hr(style="border-color:var(--border);"),
+                    # Engagement chart
+                    ui.h6("Engagement"),
+                    ui.input_checkbox("chart_show_mean", "Show Mean Line", value=True),
+                    ui.input_checkbox("chart_show_median", "Show Median Line", value=True),
+                    ui.input_text("chart_eng_x_label", "X Axis Label", value="Final Engagement"),
+                    ui.input_text("chart_eng_y_label", "Y Axis Label", value="Count"),
+                    ui.hr(style="border-color:var(--border);"),
+                    # GPA chart
+                    ui.h6("GPA"),
+                    ui.input_checkbox("chart_show_pass_line", "Show Pass Threshold", value=True),
+                    ui.input_checkbox("chart_show_dist_line", "Show Distinction Threshold", value=True),
+                    ui.input_text("chart_gpa_x_label", "X Axis Label", value="Cumulative GPA"),
+                    ui.input_text("chart_gpa_y_label", "Y Axis Label", value="Count"),
+                    ui.hr(style="border-color:var(--border);"),
+                    # Dropout timeline
+                    ui.h6("Dropout Timeline"),
+                    ui.input_slider("chart_line_width", "Line Width", min=1, max=5, value=3, step=1),
+                    ui.input_slider("chart_marker_size", "Marker Size", min=3, max=12, value=7, step=1),
+                    ui.input_text("chart_dropout_x_label", "X Axis Label", value="Week"),
+                    ui.input_text("chart_dropout_y_label", "Y Axis Label", value="Cumulative Dropout %"),
+                    ui.hr(style="border-color:var(--border);"),
+                    # General
+                    ui.h6("General"),
+                    ui.input_checkbox("chart_show_legend", "Show Legend", value=False),
+                    class_="offcanvas-body",
+                ),
+                class_="offcanvas offcanvas-end",
+                tabindex="-1",
+                id="chart_settings",
+                style="width:350px;background:var(--bg,#0F1117);color:var(--text-primary,#F1F5F9);",
+                **{"data-bs-backdrop": "true"},
+            ),
+        ),
+    )
+
+
 def results_layout() -> ui.Tag:
     """Full results panel layout."""
     return ui.div(
-        ui.h5("Results", class_="mb-3"),
+        ui.div(
+            ui.h5("Results", style="display:inline;"),
+            ui.span(_chart_settings_offcanvas(), class_="float-end"),
+            class_="mb-3",
+        ),
         summary_cards_row(),
         ui.hr(class_="my-3", style="border-color:var(--border,#1E2130);"),
         # Charts

--- a/synthed/dashboard/components/results_panel.py
+++ b/synthed/dashboard/components/results_panel.py
@@ -5,31 +5,34 @@ from __future__ import annotations
 from shiny import ui
 
 
-def summary_card(card_id: str, label: str, color_class: str = "text-primary") -> ui.Tag:
-    """A single summary metric card."""
+def summary_card(
+    card_id: str,
+    label: str,
+    color_class: str = "text-primary",
+    accent_class: str = "",
+) -> ui.Tag:
+    """A single summary metric card with semantic accent border."""
     return ui.div(
-        ui.div(label, class_="card-label",
-               style="font-size:11px;color:var(--text-secondary,#8B90A0);text-transform:uppercase;letter-spacing:0.5px;"),
+        ui.div(label, class_="card-label"),
         ui.div(
             ui.output_text(card_id, inline=True),
-            class_=f"card-value value-display {color_class}",
-            style="font-size:24px;font-weight:600;",
+            class_=f"card-value {color_class}",
         ),
         ui.div(
             ui.output_text(f"{card_id}_sub", inline=True),
-            style="font-size:10px;color:var(--text-muted,#4A4F63);font-family:'JetBrains Mono',monospace;",
+            style="font-size:10px;color:var(--text-muted);font-family:'JetBrains Mono',monospace;",
         ),
-        class_="summary-card p-3",
+        class_=f"summary-card {accent_class}".strip(),
     )
 
 
 def summary_cards_row() -> ui.Tag:
     """4 summary cards in a 2x2 grid."""
     return ui.row(
-        ui.column(6, summary_card("dropout_rate", "Dropout Rate", "text-primary")),
-        ui.column(6, summary_card("mean_engagement", "Engagement", "text-warning")),
-        ui.column(6, summary_card("mean_gpa", "Mean GPA", "text-success"), class_="mt-2"),
-        ui.column(6, summary_card("validation_grade", "Validation", "text-success"), class_="mt-2"),
+        ui.column(6, summary_card("dropout_rate", "Dropout Rate", "text-danger", "summary-card--dropout")),
+        ui.column(6, summary_card("mean_engagement", "Engagement", "text-warning", "summary-card--warning")),
+        ui.column(6, summary_card("mean_gpa", "Mean GPA", "text-info", "summary-card--info"), class_="mt-2"),
+        ui.column(6, summary_card("validation_grade", "Validation", "text-success", "summary-card--success"), class_="mt-2"),
     )
 
 

--- a/synthed/dashboard/theme.py
+++ b/synthed/dashboard/theme.py
@@ -360,6 +360,10 @@ body.light-mode .offcanvas { background: #F8FAFC !important; color: #0F172A !imp
 body.light-mode .btn-outline-secondary { border-color: #CBD5E1 !important; color: #475569 !important; }
 body.light-mode .irs--shiny .irs-line { background: #E2E8F0; }
 body.light-mode .irs--shiny .irs-handle { background: var(--accent); box-shadow: 0 0 0 3px rgba(99,102,241,0.15); }
+body.light-mode .badge-success { background: #D1FAE5 !important; color: #065F46 !important; }
+body.light-mode .badge-warning { background: #FEF3C7 !important; color: #92400E !important; }
+body.light-mode .badge-info { background: #E0E7FF !important; color: #3730A3 !important; }
+body.light-mode .btn-close-white { filter: none; }
 """
 
 # Combine generated :root with static CSS

--- a/synthed/dashboard/theme.py
+++ b/synthed/dashboard/theme.py
@@ -130,11 +130,13 @@ h6, .h6 { color: var(--text-secondary) !important; font-weight: 600; }
 .btn-primary {
     background: linear-gradient(135deg, var(--accent) 0%, #7C3AED 100%) !important;
     border: none !important;
+    border-radius: 12px !important;
     font-weight: 600;
+    box-shadow: 0 4px 15px rgba(99, 102, 241, 0.3);
     transition: box-shadow 0.2s ease, transform 0.15s ease;
 }
 .btn-primary:hover {
-    box-shadow: 0 0 16px rgba(99, 102, 241, 0.4) !important;
+    box-shadow: 0 6px 25px rgba(99, 102, 241, 0.5) !important;
     background: linear-gradient(135deg, var(--accent-light) 0%, #8B5CF6 100%) !important;
     transform: translateY(-1px);
 }
@@ -207,6 +209,46 @@ h6, .h6 { color: var(--text-secondary) !important; font-weight: 600; }
 .card-value.text-success { color: var(--success) !important; }
 .card-value.text-info { color: var(--info) !important; }
 
+/* Shiny value-box overrides (KPI cards use bslib internally) */
+.bslib-value-box .card {
+    border-radius: 12px !important;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.bslib-value-box .card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.3);
+}
+.bslib-value-box .value-box-value {
+    font-family: 'Inter', sans-serif !important;
+    font-weight: 700 !important;
+    font-size: 28px !important;
+}
+
+/* Main content scroll fix */
+[role="tabpanel"] > .container-fluid {
+    overflow-y: auto;
+    scroll-behavior: smooth;
+}
+
+/* Status text overflow fix */
+.text-end.text-secondary {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 12px;
+}
+
+/* Chart containers — subtle card frame + display fix for Shiny's display:contents */
+div.shiny-html-output[id^="chart_"] {
+    display: block !important;
+    min-height: 400px;
+}
+.js-plotly-plot {
+    border: 1px solid rgba(148, 163, 184, 0.08);
+    border-radius: 12px;
+    overflow: hidden;
+}
+
 /* Warning border */
 .param-warning { border-left: 3px solid var(--warning) !important; }
 
@@ -241,15 +283,29 @@ h6, .h6 { color: var(--text-secondary) !important; font-weight: 600; }
     padding: 4px 12px;
 }
 .preset-btn.active {
-    background: var(--accent) !important;
-    border-color: var(--accent) !important;
+    background: linear-gradient(135deg, var(--accent), #8B5CF6) !important;
+    border: none !important;
     color: #fff !important;
+    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.3);
+}
+.preset-btn:not(.active) {
+    background: var(--elevated) !important;
+    border: 1px solid rgba(148, 163, 184, 0.12) !important;
+}
+.preset-btn:not(.active):hover {
+    border-color: rgba(99, 102, 241, 0.4) !important;
 }
 
-/* Card value contrast fix */
-.card-value.text-primary { color: #3CA0E6 !important; }
-.card-value.text-warning { color: #F5A623 !important; }
-.card-value.text-success { color: #2DD4A0 !important; }
+/* Sub-section headings inside accordion (Demographics, Academic, Risk) */
+.accordion-body h6 {
+    color: var(--text-primary) !important;
+    font-size: 13px !important;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 4px;
+    margin-top: 12px !important;
+}
 
 /* Import file input placeholder fix */
 .shiny-input-container .form-control::file-selector-button {
@@ -268,6 +324,42 @@ h6, .h6 { color: var(--text-secondary) !important; font-weight: 600; }
 
 /* Offcanvas backdrop */
 .offcanvas-backdrop { background-color: rgba(0,0,0,0.6); }
+
+/* ── Light Mode Override ── */
+body.light-mode {
+    --bg: #F8FAFC;
+    --surface: #FFFFFF;
+    --elevated: #F1F5F9;
+    --border: #E2E8F0;
+    --border-hover: #CBD5E1;
+    --text-primary: #0F172A;
+    --text-secondary: #475569;
+    --text-muted: #94A3B8;
+}
+body.light-mode .navbar, body.light-mode .navbar-default {
+    background: rgba(248, 250, 252, 0.85) !important;
+    border-bottom-color: #E2E8F0 !important;
+}
+body.light-mode .navbar-brand { color: #0F172A !important; }
+body.light-mode .sidebar { background: #FFFFFF !important; }
+body.light-mode .accordion-item { background: #FFFFFF !important; }
+body.light-mode .accordion-button { background: #FFFFFF !important; color: #0F172A !important; }
+body.light-mode .accordion-body { background: #F8FAFC !important; }
+body.light-mode .form-control, body.light-mode .form-select {
+    background: #FFFFFF !important;
+    border-color: #E2E8F0 !important;
+    color: #0F172A !important;
+}
+body.light-mode .summary-card {
+    background: linear-gradient(135deg, #FFFFFF 0%, #F1F5F9 100%);
+    border-color: #E2E8F0;
+}
+body.light-mode .run-bar-sticky { background: #F8FAFC; }
+body.light-mode .shiny-notification { background: #FFFFFF !important; color: #0F172A !important; border-color: #E2E8F0 !important; }
+body.light-mode .offcanvas { background: #F8FAFC !important; color: #0F172A !important; }
+body.light-mode .btn-outline-secondary { border-color: #CBD5E1 !important; color: #475569 !important; }
+body.light-mode .irs--shiny .irs-line { background: #E2E8F0; }
+body.light-mode .irs--shiny .irs-handle { background: var(--accent); box-shadow: 0 0 0 3px rgba(99,102,241,0.15); }
 """
 
 # Combine generated :root with static CSS

--- a/synthed/dashboard/theme.py
+++ b/synthed/dashboard/theme.py
@@ -9,14 +9,17 @@ ELEVATED = "#242838"
 BORDER = "#1E2130"
 BORDER_HOVER = "#2A2D3A"
 
-TEXT_PRIMARY = "#E8EAF0"
-TEXT_SECONDARY = "#8B90A0"
-TEXT_MUTED = "#4A4F63"
+TEXT_PRIMARY = "#F1F5F9"
+TEXT_SECONDARY = "#94A3B8"
+TEXT_MUTED = "#64748B"
 
-ACCENT = "#4F8EF7"
-SUCCESS = "#2DD4A0"
-WARNING = "#F5A623"
-ERROR = "#E84545"
+ACCENT = "#6366F1"
+ACCENT_LIGHT = "#818CF8"
+ACCENT_DARK = "#4F46E5"
+SUCCESS = "#10B981"
+WARNING = "#F59E0B"
+ERROR = "#F43F5E"
+INFO = "#3B82F6"
 
 _COLOR_VARS: dict[str, str] = {
     "bg": BG,
@@ -28,9 +31,12 @@ _COLOR_VARS: dict[str, str] = {
     "text-secondary": TEXT_SECONDARY,
     "text-muted": TEXT_MUTED,
     "accent": ACCENT,
+    "accent-light": ACCENT_LIGHT,
+    "accent-dark": ACCENT_DARK,
     "success": SUCCESS,
     "warning": WARNING,
     "error": ERROR,
+    "info": INFO,
 }
 
 
@@ -52,12 +58,17 @@ body {
     color: var(--text-primary) !important;
 }
 
-/* Navbar */
+/* Navbar — glassmorphism */
 .navbar, .navbar-default {
-    background: #0A0C10 !important;
+    background: rgba(10, 12, 16, 0.75) !important;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
     border-bottom: 1px solid var(--border) !important;
+    position: sticky;
+    top: 0;
+    z-index: 1030;
 }
-.navbar-brand { color: var(--text-primary) !important; font-weight: 600; }
+.navbar-brand { color: var(--text-primary) !important; font-weight: 700; }
 .nav-link { color: var(--text-secondary) !important; }
 .nav-link.active, .nav-link:hover { color: var(--accent) !important; }
 
@@ -94,7 +105,7 @@ body {
 }
 .form-control:focus, .form-select:focus {
     border-color: var(--accent) !important;
-    box-shadow: 0 0 0 2px rgba(79, 142, 247, 0.15) !important;
+    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.15) !important;
 }
 
 /* Labels */
@@ -104,24 +115,29 @@ body {
     font-weight: 500;
 }
 
-/* Heading contrast fix — WCAG AA min 4.5:1 */
-h5, .h5 { color: #A0A5B4 !important; }
-h6, .h6 { color: #8B90A0 !important; }
+/* Heading contrast — WCAG AA */
+h5, .h5 { color: var(--text-primary) !important; font-weight: 600; }
+h6, .h6 { color: var(--text-secondary) !important; font-weight: 600; }
 
-/* Sliders */
-.irs--shiny .irs-bar { background: var(--accent); }
-.irs--shiny .irs-handle { border-color: var(--accent); background: var(--accent); }
+/* Sliders — gradient track */
+.irs--shiny .irs-bar { background: linear-gradient(90deg, var(--accent), var(--accent-light)); }
+.irs--shiny .irs-handle { border-color: var(--accent); background: #fff; box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2); }
 .irs--shiny .irs-line { background: var(--border-hover); }
 .irs--shiny .irs-single { background: var(--accent); font-family: 'JetBrains Mono', monospace; font-size: 11px; }
 .irs--shiny .irs-min, .irs--shiny .irs-max { color: var(--text-muted); }
 
-/* Buttons */
+/* Buttons — gradient + glow */
 .btn-primary {
-    background: var(--accent) !important;
-    border-color: var(--accent) !important;
+    background: linear-gradient(135deg, var(--accent) 0%, #7C3AED 100%) !important;
+    border: none !important;
     font-weight: 600;
+    transition: box-shadow 0.2s ease, transform 0.15s ease;
 }
-.btn-primary:hover { background: #3D7AE0 !important; }
+.btn-primary:hover {
+    box-shadow: 0 0 16px rgba(99, 102, 241, 0.4) !important;
+    background: linear-gradient(135deg, var(--accent-light) 0%, #8B5CF6 100%) !important;
+    transform: translateY(-1px);
+}
 .btn-outline-secondary {
     border-color: var(--border-hover) !important;
     color: var(--text-secondary) !important;
@@ -151,30 +167,45 @@ h6, .h6 { color: #8B90A0 !important; }
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: var(--border-hover); border-radius: 3px; }
 
-/* JetBrains Mono for numeric outputs */
+/* JetBrains Mono for numeric inputs */
 .value-display, .metric-value {
     font-family: 'JetBrains Mono', monospace;
     font-weight: 600;
 }
 
-/* Summary card styling */
+/* Summary card — glassmorphism + semantic accent */
 .summary-card {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: 10px;
-    padding: 14px 16px;
+    background: linear-gradient(135deg, var(--surface) 0%, var(--elevated) 100%);
+    border: 1px solid rgba(148, 163, 184, 0.08);
+    border-left: 3px solid var(--accent);
+    border-radius: 12px;
+    padding: 20px 24px;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
+.summary-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.3);
+}
+.summary-card--dropout  { border-left-color: var(--error); }
+.summary-card--warning  { border-left-color: var(--warning); }
+.summary-card--success  { border-left-color: var(--success); }
+.summary-card--info     { border-left-color: var(--info, var(--accent)); }
 .summary-card .card-label {
     font-size: 11px;
-    color: var(--text-secondary);
+    color: var(--text-muted);
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: 0.8px;
+    font-weight: 500;
 }
 .summary-card .card-value {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 24px;
-    font-weight: 600;
+    font-family: 'Inter', sans-serif;
+    font-size: 28px;
+    font-weight: 700;
 }
+.card-value.text-danger { color: var(--error) !important; }
+.card-value.text-warning { color: var(--warning) !important; }
+.card-value.text-success { color: var(--success) !important; }
+.card-value.text-info { color: var(--info) !important; }
 
 /* Warning border */
 .param-warning { border-left: 3px solid var(--warning) !important; }


### PR DESCRIPTION
## Summary

- **Visual redesign**: indigo palette, glassmorphism navbar/cards, semantic KPI card accents (dropout=red, engagement=warning, GPA=info, validation=success)
- **Dark/light theme toggle**: CSS variable override for light mode, Plotly charts restyle on toggle via `Plotly.relayout`/`Plotly.restyle` (font, grid, hover, bar edge, polar axes)
- **Chart settings offcanvas**: bin count, opacity, bar edge, mean/median/threshold lines, axis labels, line width, marker size
- **Accessibility**: theme toggle button has `aria-label`, `aria-pressed`, `title` — all synced on click

## Changes

- `theme.py` — indigo color palette, glassmorphism CSS, light mode override block, summary card semantic accents
- `app.py` — theme toggle JS with chart restyle, accessible button attrs
- `charts.py` — transparent backgrounds, grid color, colorway, height defaults, `ChartSettings` dataclass
- `results_panel.py` — summary cards with semantic accent classes, chart settings offcanvas UI

## Test plan

- [x] 772 tests pass (`pytest tests/ -x -q`)
- [x] Dashboard imports successfully
- [ ] Manual: toggle dark → light → dark, verify cards/navbar/charts all switch
- [ ] Manual: open chart settings offcanvas, adjust bins/opacity/lines, verify charts update
- [ ] Manual: screen reader announces "Switch to light/dark mode" on toggle button

🤖 Generated with [Claude Code](https://claude.com/claude-code)