### PR TITLE
feat: calibration pipeline upgrade — HV tracking, re-evaluation, replicated calibration

### DIFF
--- a/run_calibration.py
+++ b/run_calibration.py
@@ -30,12 +30,12 @@ PROFILE_NAMES = ["default"]
 OUTPUT_DIR = Path("calibration_output")
 
 
-def run_sobol(n_students: int, seed: int, n_workers: int = 1) -> list[SobolRanking]:
+def run_sobol(n_students: int, seed: int, n_workers: int = 1, n_samples: int = 128) -> list[SobolRanking]:
     """Run single Sobol analysis and return dropout rankings."""
-    logger.info("Running Sobol analysis (n_students=%d, n_workers=%d)...", n_students, n_workers)
+    logger.info("Running Sobol analysis (n_students=%d, n_samples=%d, n_workers=%d)...", n_students, n_samples, n_workers)
     t0 = time.time()
     analyzer = SobolAnalyzer(n_students=n_students, seed=seed, n_workers=n_workers)
-    results = analyzer.run()
+    results = analyzer.run(n_samples=n_samples)
     dropout_result = next(r for r in results if r.metric == "dropout_rate")
     rankings = analyzer.rank(dropout_result)
     logger.info("Sobol complete in %.1fs, %d parameters ranked", time.time() - t0, len(rankings))
@@ -66,12 +66,14 @@ def calibrate_profile(
     cal_time = time.time() - t0
 
     # Validate
-    logger.info("Validating knee-point (n=500, 3 seeds)...")
+    validation_n = 1000
+    validation_seeds = (42, 123, 456, 789, 2024, 1337, 7777, 9999, 31415, 27182)
+    logger.info("Validating knee-point (n=%d, %d seeds)...", validation_n, len(validation_seeds))
     d_mean, d_std, g_mean, g_std = cal.validate_solution(
         result.knee_point,
         profile=profile_name,
-        n_students=500,
-        seeds=(42, 123, 456),
+        n_students=validation_n,
+        seeds=validation_seeds,
     )
 
     profile = PROFILES[profile_name]
@@ -124,15 +126,15 @@ def main():
     args.workers = max(1, min(args.workers, os.cpu_count() or 8))
 
     if args.quick:
-        n_students, pop_size, n_trials, sobol_top_n = 50, 20, 500, 10
+        n_students, pop_size, n_trials, sobol_top_n, sobol_n_samples = 100, 20, 500, 10, 128
     else:
-        n_students, pop_size, n_trials, sobol_top_n = 100, 160, 12800, 20
+        n_students, pop_size, n_trials, sobol_top_n, sobol_n_samples = 500, 200, 62_000, 20, 512
 
     profiles = [args.profile] if args.profile else PROFILE_NAMES
     OUTPUT_DIR.mkdir(exist_ok=True)
 
     # Step 1: Sobol (once)
-    rankings = run_sobol(n_students=n_students, seed=args.seed, n_workers=args.workers)
+    rankings = run_sobol(n_students=n_students, seed=args.seed, n_workers=args.workers, n_samples=sobol_n_samples)
 
     # Step 2: Calibrate each profile
     cal = NSGAIICalibrator(n_students=n_students, seed=args.seed, n_workers=args.workers)

--- a/run_calibration.py
+++ b/run_calibration.py
@@ -16,6 +16,7 @@ import time
 from pathlib import Path
 
 from synthed.analysis.nsga2_calibrator import NSGAIICalibrator
+from synthed.analysis.pareto_utils import compare_knee_points
 from synthed.analysis.sobol_sensitivity import SobolAnalyzer, SobolRanking
 from synthed.benchmarks.profiles import PROFILES
 
@@ -26,6 +27,8 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 PROFILE_NAMES = ["default"]
+
+CALIBRATION_SEEDS = (42, 2024)
 
 OUTPUT_DIR = Path("calibration_output")
 
@@ -49,6 +52,7 @@ def calibrate_profile(
     pop_size: int,
     n_trials: int,
     sobol_top_n: int,
+    quick_mode: bool = False,
 ) -> dict:
     """Calibrate one profile and return results as dict."""
     logger.info("=" * 60)
@@ -65,12 +69,25 @@ def calibrate_profile(
     )
     cal_time = time.time() - t0
 
+    # Re-evaluate Pareto front for noise-free knee-point selection
+    if not quick_mode:
+        logger.info("Re-evaluating Pareto front (n=2000, 3 seeds)...")
+        reeval_result = cal.reevaluate_pareto_front(
+            pareto_front=result.pareto_front,
+            profile=profile_name,
+            n_students=2000,
+            seeds=(42, 123, 456),
+        )
+        knee_for_validation = reeval_result.knee_point
+    else:
+        knee_for_validation = result.knee_point
+
     # Validate
     validation_n = 1000
     validation_seeds = (42, 123, 456, 789, 2024, 1337, 7777, 9999, 31415, 27182)
     logger.info("Validating knee-point (n=%d, %d seeds)...", validation_n, len(validation_seeds))
     d_mean, d_std, g_mean, g_std = cal.validate_solution(
-        result.knee_point,
+        knee_for_validation,
         profile=profile_name,
         n_students=validation_n,
         seeds=validation_seeds,
@@ -85,12 +102,12 @@ def calibrate_profile(
         "n_evaluations": result.n_evaluations,
         "calibration_time_s": round(cal_time, 1),
         "knee_point": {
-            "dropout_error": round(result.knee_point.dropout_error, 4),
-            "gpa_error": round(result.knee_point.gpa_error, 4),
-            "achieved_dropout": round(result.knee_point.achieved_dropout, 4),
-            "achieved_gpa": round(result.knee_point.achieved_gpa, 4),
-            "achieved_engagement": round(result.knee_point.achieved_engagement, 4),
-            "params": {k: round(v, 6) for k, v in result.knee_point.params.items()},
+            "dropout_error": round(knee_for_validation.dropout_error, 4),
+            "gpa_error": round(knee_for_validation.gpa_error, 4),
+            "achieved_dropout": round(knee_for_validation.achieved_dropout, 4),
+            "achieved_gpa": round(knee_for_validation.achieved_gpa, 4),
+            "achieved_engagement": round(knee_for_validation.achieved_engagement, 4),
+            "params": {k: round(v, 6) for k, v in knee_for_validation.params.items()},
         },
         "validation": {
             "dropout_mean": round(d_mean, 4),
@@ -101,15 +118,16 @@ def calibrate_profile(
             "expected_range": [lo, hi],
         },
         "parameter_names": list(result.parameter_names),
+        "hv_history": list(result.hv_history),
     }
 
     logger.info(
         "Result: Pareto=%d, knee dropout=%.1f%% (target %.0f%%-%.0f%%), "
         "gpa=%.2f, validation=%.1f%%+/-%.1f%%",
         len(result.pareto_front),
-        result.knee_point.achieved_dropout * 100,
+        knee_for_validation.achieved_dropout * 100,
         lo * 100, hi * 100,
-        result.knee_point.achieved_gpa,
+        knee_for_validation.achieved_gpa,
         d_mean * 100, d_std * 100,
     )
     return summary
@@ -136,47 +154,72 @@ def main():
     # Step 1: Sobol (once)
     rankings = run_sobol(n_students=n_students, seed=args.seed, n_workers=args.workers, n_samples=sobol_n_samples)
 
-    # Step 2: Calibrate each profile
-    cal = NSGAIICalibrator(n_students=n_students, seed=args.seed, n_workers=args.workers)
-    all_results = []
-    total_t0 = time.time()
+    # Step 2: Calibrate each profile with replicated seeds
+    calibration_seeds = CALIBRATION_SEEDS if not args.quick else (args.seed,)
+    seed_knee_points: dict[str, dict] = {}
 
-    for name in profiles:
-        try:
-            summary = calibrate_profile(
-                cal, name, rankings, pop_size, n_trials, sobol_top_n,
-            )
-            all_results.append(summary)
+    for cal_seed in calibration_seeds:
+        logger.info("=" * 60)
+        logger.info("NSGA-II seed: %d", cal_seed)
+        logger.info("=" * 60)
 
-            # Save per-profile JSON
-            out_file = OUTPUT_DIR / f"nsga2_{name}.json"
-            out_file.write_text(json.dumps(summary, indent=2))
-            logger.info("Saved: %s", out_file)
+        cal = NSGAIICalibrator(n_students=n_students, seed=cal_seed, n_workers=args.workers)
+        all_results = []
+        total_t0 = time.time()
 
-        except Exception as e:
-            logger.error("Failed to calibrate %s: %s", name, e)
-            all_results.append({"profile": name, "error": str(e)})
+        for name in profiles:
+            try:
+                summary = calibrate_profile(
+                    cal, name, rankings, pop_size, n_trials, sobol_top_n,
+                    quick_mode=args.quick,
+                )
+                all_results.append(summary)
+                seed_knee_points.setdefault(name, {})[cal_seed] = summary["knee_point"]
 
-    # Summary
-    total_time = time.time() - total_t0
-    logger.info("=" * 60)
-    logger.info("CALIBRATION COMPLETE (%.1f min)", total_time / 60)
-    logger.info("=" * 60)
+                out_file = OUTPUT_DIR / f"nsga2_{name}_seed{cal_seed}.json"
+                out_file.write_text(json.dumps(summary, indent=2))
+                logger.info("Saved: %s", out_file)
 
-    for r in all_results:
-        if "error" in r:
-            logger.info("  %s: FAILED — %s", r["profile"], r["error"])
-        else:
-            v = r["validation"]
-            logger.info(
-                "  %s: dropout=%.1f%% +/-%.1f%% (range %.0f%%-%.0f%%) %s",
-                r["profile"],
-                v["dropout_mean"] * 100,
-                v["dropout_std"] * 100,
-                v["expected_range"][0] * 100,
-                v["expected_range"][1] * 100,
-                "IN RANGE" if v["in_range"] else "OUT OF RANGE",
-            )
+            except Exception as e:
+                logger.error("Failed to calibrate %s (seed=%d): %s", name, cal_seed, e)
+                all_results.append({"profile": name, "error": str(e)})
+
+        total_time = time.time() - total_t0
+        logger.info("Seed %d complete (%.1f min)", cal_seed, total_time / 60)
+
+    # Compare knee-points across seeds (if replicated)
+    if len(calibration_seeds) > 1:
+        logger.info("=" * 60)
+        logger.info("KNEE-POINT COMPARISON")
+        logger.info("=" * 60)
+        for name, knees in seed_knee_points.items():
+            if len(knees) >= 2:
+                seeds_list = sorted(knees.keys())
+                from synthed.analysis.pareto_utils import ParetoSolution
+                sol_a = ParetoSolution(
+                    params=knees[seeds_list[0]]["params"],
+                    dropout_error=knees[seeds_list[0]]["dropout_error"],
+                    gpa_error=knees[seeds_list[0]]["gpa_error"],
+                    engagement_error=knees[seeds_list[0]].get("achieved_engagement", 0.5),
+                    achieved_dropout=knees[seeds_list[0]]["achieved_dropout"],
+                    achieved_gpa=knees[seeds_list[0]]["achieved_gpa"],
+                    achieved_engagement=knees[seeds_list[0]].get("achieved_engagement", 0.5),
+                )
+                sol_b = ParetoSolution(
+                    params=knees[seeds_list[1]]["params"],
+                    dropout_error=knees[seeds_list[1]]["dropout_error"],
+                    gpa_error=knees[seeds_list[1]]["gpa_error"],
+                    engagement_error=knees[seeds_list[1]].get("achieved_engagement", 0.5),
+                    achieved_dropout=knees[seeds_list[1]]["achieved_dropout"],
+                    achieved_gpa=knees[seeds_list[1]]["achieved_gpa"],
+                    achieved_engagement=knees[seeds_list[1]].get("achieved_engagement", 0.5),
+                )
+                dist = compare_knee_points(sol_a, sol_b)
+                robust = "ROBUST" if dist < 0.1 else "DIVERGENT"
+                logger.info(
+                    "  %s: distance=%.4f — %s",
+                    name, dist, robust,
+                )
 
     # Save combined
     combined = OUTPUT_DIR / "nsga2_all_profiles.json"

--- a/synthed/analysis/nsga2_calibrator.py
+++ b/synthed/analysis/nsga2_calibrator.py
@@ -406,6 +406,78 @@ class NSGAIICalibrator:
             float(np.std(gpas)),
         )
 
+    def reevaluate_pareto_front(
+        self,
+        pareto_front: tuple[ParetoSolution, ...],
+        profile: str | BenchmarkProfile,
+        n_students: int = 2000,
+        seeds: tuple[int, ...] = (42, 123, 456),
+    ) -> ParetoResult:
+        """Re-evaluate each Pareto solution at higher N and re-select knee-point.
+
+        Produces cleaner objective values by averaging over multiple seeds
+        with a larger population, reducing Monte Carlo noise in knee-point
+        selection.
+        """
+        from ..benchmarks.profiles import PROFILES
+
+        if isinstance(profile, str):
+            resolved = PROFILES[profile]
+            profile_name = profile
+        else:
+            resolved = profile
+            profile_name = resolved.name
+
+        target_dropout = resolved.reference_stats.dropout_rate
+        target_gpa = resolved.reference_stats.gpa_mean
+        fixed = self._build_fixed_overrides(resolved)
+
+        cleaned: list[ParetoSolution] = []
+        for sol in pareto_front:
+            dropouts: list[float] = []
+            gpas: list[float] = []
+            engagements: list[float] = []
+            for s in seeds:
+                overrides = {**fixed, **sol.params}
+                result = run_simulation_with_overrides(
+                    overrides=overrides,
+                    n_students=n_students,
+                    seed=s,
+                    default_config=resolved.persona_config,
+                    calibration_mode=True,
+                )
+                dropouts.append(result["dropout_rate"])
+                gpas.append(result["mean_gpa"])
+                engagements.append(result["mean_engagement"])
+
+            mean_d = float(np.mean(dropouts))
+            mean_g = float(np.mean(gpas))
+            mean_e = float(np.mean(engagements))
+            cleaned.append(ParetoSolution(
+                params=sol.params,
+                dropout_error=abs(mean_d - target_dropout),
+                gpa_error=abs(mean_g - target_gpa),
+                engagement_error=abs(mean_e - _TARGET_ENGAGEMENT),
+                achieved_dropout=mean_d,
+                achieved_gpa=mean_g,
+                achieved_engagement=mean_e,
+            ))
+
+        cleaned_front = tuple(cleaned)
+        knee = find_knee_point(cleaned_front)
+        logger.info(
+            "Re-evaluation complete: %d solutions, knee dropout_err=%.4f gpa_err=%.4f",
+            len(cleaned_front), knee.dropout_error, knee.gpa_error,
+        )
+
+        return ParetoResult(
+            profile_name=profile_name,
+            pareto_front=cleaned_front,
+            knee_point=knee,
+            n_evaluations=len(pareto_front) * len(seeds),
+            parameter_names=tuple(sorted(pareto_front[0].params.keys())) if pareto_front else (),
+        )
+
     def _build_fixed_overrides(
         self, profile: BenchmarkProfile,
     ) -> dict[str, float]:

--- a/synthed/analysis/nsga2_calibrator.py
+++ b/synthed/analysis/nsga2_calibrator.py
@@ -11,7 +11,7 @@ import optuna
 from optuna.samplers import NSGAIISampler
 
 from ._sim_runner import run_simulation_with_overrides
-from .pareto_utils import ParetoSolution, ParetoResult, find_knee_point
+from .pareto_utils import ParetoSolution, ParetoResult, find_knee_point, compute_hypervolume
 from .sobol_sensitivity import (
     SobolAnalyzer,
     SobolParameter,
@@ -122,30 +122,6 @@ class NSGAIICalibrator:
         fixed_overrides = self._build_fixed_overrides(resolved)
         lo, hi = resolved.expected_dropout_range
 
-        # Objective (used in sequential mode only)
-        def objective(trial: optuna.Trial) -> tuple[float, float]:
-            overrides = dict(fixed_overrides)
-            for p in params:
-                overrides[p.name] = trial.suggest_float(
-                    p.name, p.lower, p.upper, log=p.log_scale,
-                )
-            result = run_simulation_with_overrides(
-                overrides=overrides,
-                n_students=self._n_students,
-                seed=self._seed,
-                default_config=resolved.persona_config,
-                calibration_mode=True,
-            )
-            trial.set_user_attr("achieved_dropout", result["dropout_rate"])
-            trial.set_user_attr("achieved_gpa", result["mean_gpa"])
-            trial.set_user_attr("achieved_engagement", result["mean_engagement"])
-            trial.set_user_attr("pass_rate", result.get("pass_rate", 0.0))
-            trial.set_user_attr("distinction_rate", result.get("distinction_rate", 0.0))
-
-            dropout_error = abs(result["dropout_rate"] - target_dropout)
-            gpa_error = abs(result["mean_gpa"] - target_gpa)
-            return dropout_error, gpa_error
-
         # Constraints
         def constraints_func(
             trial: optuna.trial.FrozenTrial,
@@ -175,12 +151,15 @@ class NSGAIICalibrator:
         )
 
         if self._n_workers > 1:
-            self._run_parallel(
+            hv_history = self._run_parallel(
                 study, params, fixed_overrides, resolved,
                 target_dropout, target_gpa, n_trials, pop_size,
             )
         else:
-            study.optimize(objective, n_trials=n_trials, n_jobs=1)
+            hv_history = self._run_sequential(
+                study, params, fixed_overrides, resolved,
+                target_dropout, target_gpa, n_trials, pop_size,
+            )
 
         # Extract Pareto front
         best_trials = study.best_trials
@@ -221,6 +200,7 @@ class NSGAIICalibrator:
             knee_point=knee,
             n_evaluations=len(study.trials),
             parameter_names=param_names,
+            hv_history=tuple(hv_history),
         )
 
     def _run_parallel(
@@ -233,7 +213,7 @@ class NSGAIICalibrator:
         target_gpa: float,
         n_trials: int,
         pop_size: int,
-    ) -> None:
+    ) -> list[float]:
         """Run trials with ProcessPoolExecutor for GIL bypass.
 
         Uses Optuna's ask/tell API: ask for a batch of trials, build
@@ -243,7 +223,11 @@ class NSGAIICalibrator:
 
         Pool is created once and reused across all generations to avoid
         repeated process spawn overhead on Windows.
+
+        Returns per-generation hypervolume history.
         """
+        ref_point = np.array([0.25, 2.0])
+        hv_history: list[float] = []
         worker = partial(
             run_simulation_with_overrides,
             n_students=self._n_students,
@@ -307,11 +291,79 @@ class NSGAIICalibrator:
                         except RuntimeError:
                             pass  # already told as FAIL in the as_completed loop
 
+                # HV tracking per generation
+                best = study.best_trials
+                if best:
+                    pts = np.array([(t.values[0], t.values[1]) for t in best])
+                    hv = compute_hypervolume(pts, ref_point)
+                    hv_history.append(hv)
+
                 completed += batch_size
                 if completed % (pop_size * 5) == 0:
                     logger.info("Progress: %d/%d trials", completed, n_trials)
         finally:
             pool.shutdown(wait=False, cancel_futures=True)
+        return hv_history
+
+    def _run_sequential(
+        self,
+        study: optuna.Study,
+        params: tuple[SobolParameter, ...],
+        fixed_overrides: dict[str, float],
+        profile: BenchmarkProfile,
+        target_dropout: float,
+        target_gpa: float,
+        n_trials: int,
+        pop_size: int,
+    ) -> list[float]:
+        """Run trials sequentially with ask/tell API and HV tracking."""
+        ref_point = np.array([0.25, 2.0])
+        hv_history: list[float] = []
+        completed = 0
+
+        while completed < n_trials:
+            batch_size = min(pop_size, n_trials - completed)
+
+            for _ in range(batch_size):
+                trial = study.ask()
+                overrides = dict(fixed_overrides)
+                for p in params:
+                    overrides[p.name] = trial.suggest_float(
+                        p.name, p.lower, p.upper, log=p.log_scale,
+                    )
+                try:
+                    result = run_simulation_with_overrides(
+                        overrides=overrides,
+                        n_students=self._n_students,
+                        seed=self._seed,
+                        default_config=profile.persona_config,
+                        calibration_mode=True,
+                    )
+                    trial.set_user_attr("achieved_dropout", result["dropout_rate"])
+                    trial.set_user_attr("achieved_gpa", result["mean_gpa"])
+                    trial.set_user_attr("achieved_engagement", result["mean_engagement"])
+                    trial.set_user_attr("pass_rate", result.get("pass_rate", 0.0))
+                    trial.set_user_attr("distinction_rate", result.get("distinction_rate", 0.0))
+
+                    dropout_error = abs(result["dropout_rate"] - target_dropout)
+                    gpa_error = abs(result["mean_gpa"] - target_gpa)
+                    study.tell(trial, (dropout_error, gpa_error))
+                except Exception as e:
+                    logger.warning("Trial %d failed: %s", trial.number, e)
+                    study.tell(trial, state=optuna.trial.TrialState.FAIL)
+
+            completed += batch_size
+
+            best = study.best_trials
+            if best:
+                pts = np.array([(t.values[0], t.values[1]) for t in best])
+                hv = compute_hypervolume(pts, ref_point)
+                hv_history.append(hv)
+
+            if completed % (pop_size * 5) == 0:
+                logger.info("Progress: %d/%d trials", completed, n_trials)
+
+        return hv_history
 
     def validate_solution(
         self,

--- a/synthed/analysis/nsga2_calibrator.py
+++ b/synthed/analysis/nsga2_calibrator.py
@@ -66,7 +66,7 @@ class NSGAIICalibrator:
 
     def __init__(
         self,
-        n_students: int = 100,
+        n_students: int = 500,
         seed: int = 42,
         n_workers: int = 1,
     ) -> None:

--- a/synthed/analysis/pareto_utils.py
+++ b/synthed/analysis/pareto_utils.py
@@ -31,6 +31,7 @@ class ParetoResult:
     validation_gpa_mean: float | None = None
     validation_gpa_std: float | None = None
     validation_seeds: tuple[int, ...] = ()
+    hv_history: tuple[float, ...] = ()
 
 
 def find_knee_point(front: tuple[ParetoSolution, ...]) -> ParetoSolution:
@@ -119,3 +120,27 @@ def compute_hypervolume(
         volume += (x_next - x_i) * (ref_y - best_y)
 
     return float(volume)
+
+
+def compare_knee_points(
+    a: ParetoSolution,
+    b: ParetoSolution,
+) -> float:
+    """Normalized Euclidean distance between two knee-point param vectors.
+
+    Each parameter's difference is divided by the range (max of abs values)
+    of the two values. Returns the RMS of these normalized differences.
+    If all params are identical, returns 0.0.
+    """
+    keys = sorted(a.params.keys())
+    if not keys:
+        return 0.0
+    diffs = []
+    for k in keys:
+        va, vb = a.params[k], b.params[k]
+        r = max(abs(va), abs(vb))
+        if r == 0:
+            diffs.append(0.0)
+        else:
+            diffs.append(((va - vb) / r) ** 2)
+    return float(np.sqrt(sum(diffs) / len(diffs)))

--- a/synthed/analysis/pareto_utils.py
+++ b/synthed/analysis/pareto_utils.py
@@ -66,3 +66,56 @@ def find_knee_point(front: tuple[ParetoSolution, ...]) -> ParetoSolution:
         line_vec[0] * diffs[:, 1] - line_vec[1] * diffs[:, 0]
     ) / line_len
     return sorted_front[int(np.argmax(distances))]
+
+
+def compute_hypervolume(
+    points: np.ndarray, reference_point: np.ndarray
+) -> float:
+    """2D hypervolume indicator via sweep-line (Fonseca et al., 2006).
+
+    Computes the area dominated by *points* and bounded by *reference_point*.
+    Both objectives are assumed to be minimised.
+
+    Parameters
+    ----------
+    points : np.ndarray
+        (N, 2) array of objective vectors.
+    reference_point : np.ndarray
+        (2,) reference (upper-bound) vector.
+
+    Returns
+    -------
+    float
+        Dominated hypervolume (area).  Zero when *points* is empty or no
+        point strictly dominates the reference on both objectives.
+    """
+    if points.shape[0] == 0:
+        return 0.0
+
+    ref_x, ref_y = reference_point[0], reference_point[1]
+
+    # Keep only points strictly below the reference on both objectives
+    mask = (points[:, 0] < ref_x) & (points[:, 1] < ref_y)
+    valid = points[mask]
+    if valid.shape[0] == 0:
+        return 0.0
+
+    # Sort by first objective ascending
+    order = np.argsort(valid[:, 0])
+    sorted_pts = valid[order]
+
+    volume = 0.0
+    best_y = ref_y  # best (lowest) second-objective value seen so far
+
+    for i in range(sorted_pts.shape[0]):
+        x_i = sorted_pts[i, 0]
+        y_i = sorted_pts[i, 1]
+        best_y = min(best_y, y_i)
+        x_next = (
+            sorted_pts[i + 1, 0]
+            if i + 1 < sorted_pts.shape[0]
+            else ref_x
+        )
+        volume += (x_next - x_i) * (ref_y - best_y)
+
+    return float(volume)

--- a/tests/test_nsga2_calibrator.py
+++ b/tests/test_nsga2_calibrator.py
@@ -200,3 +200,30 @@ class TestNSGAIIIntegration:
         assert d_std >= 0.0
         assert 0.0 <= g_mean <= 4.0
         assert g_std >= 0.0
+
+
+class TestReevaluatePareto:
+    @pytest.mark.slow
+    def test_reevaluate_returns_new_pareto_result(self):
+        cal = NSGAIICalibrator(n_students=30, seed=42)
+        s1 = ParetoSolution(
+            params={"grading.grade_floor": 0.45},
+            dropout_error=0.05, gpa_error=0.1, engagement_error=0.05,
+            achieved_dropout=0.37, achieved_gpa=2.5, achieved_engagement=0.5,
+        )
+        s2 = ParetoSolution(
+            params={"grading.grade_floor": 0.50},
+            dropout_error=0.08, gpa_error=0.05, engagement_error=0.03,
+            achieved_dropout=0.34, achieved_gpa=2.7, achieved_engagement=0.47,
+        )
+        front = (s1, s2)
+        result = cal.reevaluate_pareto_front(
+            pareto_front=front,
+            profile="default",
+            n_students=30,
+            seeds=(42, 123),
+        )
+        assert isinstance(result, ParetoResult)
+        assert len(result.pareto_front) <= 2
+        assert result.knee_point is not None
+        assert result.profile_name == "default"

--- a/tests/test_nsga2_calibrator.py
+++ b/tests/test_nsga2_calibrator.py
@@ -88,6 +88,43 @@ class TestNSGAIICalibrator:
             cal.run("nonexistent_profile", n_trials=10)
 
 
+class TestHVTracking:
+    @pytest.mark.slow
+    def test_run_populates_hv_history(self, monkeypatch):
+        import random
+        rng = random.Random(42)
+
+        def _mock_sim(**kwargs):
+            return {
+                "dropout_rate": 0.35 + rng.random() * 0.25,
+                "mean_gpa": 2.0 + rng.random() * 1.5,
+                "mean_engagement": 0.3 + rng.random() * 0.4,
+            }
+
+        monkeypatch.setattr(
+            "synthed.analysis.nsga2_calibrator.run_simulation_with_overrides",
+            _mock_sim,
+        )
+
+        rankings = [
+            SobolRanking(parameter="grading.grade_floor", s1=0.2, st=0.3, interaction=0.1, rank=1),
+            SobolRanking(parameter="kember._QUALITY_FACTOR", s1=0.15, st=0.25, interaction=0.1, rank=2),
+            SobolRanking(parameter="gonzalez._RECOVERY_BASE", s1=0.1, st=0.2, interaction=0.1, rank=3),
+        ]
+
+        cal = NSGAIICalibrator(n_students=30, seed=42)
+        result = cal.run(
+            profile="default",
+            pop_size=5,
+            n_trials=20,
+            sobol_rankings=rankings,
+            sobol_top_n=3,
+        )
+
+        assert len(result.hv_history) > 0
+        assert all(hv >= 0 for hv in result.hv_history)
+
+
 class TestNSGAIIIntegration:
     """Integration test with a very small NSGA-II run."""
 

--- a/tests/test_pareto_utils.py
+++ b/tests/test_pareto_utils.py
@@ -6,6 +6,7 @@ from dataclasses import fields
 import numpy as np
 from synthed.analysis.pareto_utils import (
     ParetoSolution, ParetoResult, find_knee_point, compute_hypervolume,
+    compare_knee_points,
 )
 
 
@@ -128,3 +129,35 @@ class TestComputeHypervolume:
         hv = compute_hypervolume(points, ref)
         # Sweep-line: (3-1)*(6-5) + (5-3)*(6-3) + (6-5)*(6-1) = 2+6+5 = 13
         assert hv == pytest.approx(13.0)
+
+
+class TestCompareKneePoints:
+    def test_identical_knee_points_return_zero(self):
+        s = _sol(0.1, 0.2, params={"a": 1.0, "b": 2.0})
+        dist = compare_knee_points(s, s)
+        assert dist == pytest.approx(0.0)
+
+    def test_different_knee_points_return_positive(self):
+        s1 = _sol(0.1, 0.2, params={"a": 0.0, "b": 0.0})
+        s2 = _sol(0.3, 0.4, params={"a": 1.0, "b": 1.0})
+        dist = compare_knee_points(s1, s2)
+        assert dist > 0.0
+
+    def test_normalized_distance_is_unit_scale(self):
+        s1 = _sol(0.1, 0.2, params={"a": 0.0, "b": 0.0})
+        s2 = _sol(0.3, 0.4, params={"a": 1.0, "b": 1.0})
+        dist = compare_knee_points(s1, s2)
+        assert dist == pytest.approx(1.0)
+
+
+class TestParetoResultHvHistory:
+    def test_hv_history_default_empty(self):
+        sol = _sol(0.1, 0.2)
+        result = ParetoResult(
+            profile_name="test",
+            pareto_front=(sol,),
+            knee_point=sol,
+            n_evaluations=100,
+            parameter_names=("engine._X",),
+        )
+        assert result.hv_history == ()

--- a/tests/test_pareto_utils.py
+++ b/tests/test_pareto_utils.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import pytest
 from dataclasses import fields
 
+import numpy as np
 from synthed.analysis.pareto_utils import (
-    ParetoSolution, ParetoResult, find_knee_point,
+    ParetoSolution, ParetoResult, find_knee_point, compute_hypervolume,
 )
 
 
@@ -96,3 +97,34 @@ class TestFindKneePoint:
         s3 = _sol(1.0, 0.0)
         knee = find_knee_point((s1, s2, s3))
         assert knee.dropout_error == pytest.approx(0.0)
+
+
+class TestComputeHypervolume:
+    def test_single_point(self):
+        points = np.array([[1.0, 2.0]])
+        ref = np.array([3.0, 4.0])
+        hv = compute_hypervolume(points, ref)
+        assert hv == pytest.approx(4.0)  # (3-1) * (4-2)
+
+    def test_two_points_non_overlapping(self):
+        points = np.array([[1.0, 3.0], [2.0, 1.0]])
+        ref = np.array([4.0, 4.0])
+        hv = compute_hypervolume(points, ref)
+        assert hv == pytest.approx(7.0)
+
+    def test_empty_points_returns_zero(self):
+        points = np.empty((0, 2))
+        ref = np.array([1.0, 1.0])
+        assert compute_hypervolume(points, ref) == 0.0
+
+    def test_point_dominated_by_ref_only(self):
+        points = np.array([[5.0, 5.0]])
+        ref = np.array([3.0, 3.0])
+        assert compute_hypervolume(points, ref) == 0.0
+
+    def test_three_points_known_area(self):
+        points = np.array([[1.0, 5.0], [3.0, 3.0], [5.0, 1.0]])
+        ref = np.array([6.0, 6.0])
+        hv = compute_hypervolume(points, ref)
+        # Sweep-line: (3-1)*(6-5) + (5-3)*(6-3) + (6-5)*(6-1) = 2+6+5 = 13
+        assert hv == pytest.approx(13.0)


### PR DESCRIPTION
## Summary

- **Parameter updates**: n_students 100→500, pop_size 160→200, n_trials 12.8K→62K, Sobol n_samples 128→512, validation 3→10 seeds at N=1000
- **Hypervolume convergence tracking**: per-generation HV computed via 2D sweep-line algorithm, stored in output JSON
- **Sequential path refactor**: replaced `study.optimize()` with manual ask/tell loop (symmetry with parallel path)
- **Pareto front re-evaluation**: `reevaluate_pareto_front()` at N=2000 for noise-free knee-point selection
- **Replicated calibration**: NSGA-II runs with 2 seeds (42, 2024), knee-point comparison via normalized Euclidean distance
- **New utility functions**: `compute_hypervolume()`, `compare_knee_points()` in `pareto_utils.py`

## Methodology

Full statistical justification in `docs/calibration-methodology.md` — power analysis, Sobol/NSGA-II method selection, NAF computation, validation CI analysis. 16 academic references.

## Changes

| File | Lines | What |
|------|-------|------|
| `pareto_utils.py` | +78 | `compute_hypervolume`, `compare_knee_points`, `hv_history` field |
| `nsga2_calibrator.py` | +92 | HV tracking, `_run_sequential`, `reevaluate_pareto_front` |
| `run_calibration.py` | +75 | param updates, n_samples passthrough, seed loop, re-evaluation |
| `test_pareto_utils.py` | +67 | 9 new tests (HV, compare, hv_history) |
| `test_nsga2_calibrator.py` | +64 | 2 new tests (HV tracking, re-evaluation) |

## Test plan

- [x] 783 tests pass (772 existing + 11 new)
- [x] ruff clean
- [x] Quick-mode smoke test produces valid output with `hv_history`
- [ ] Full calibration run (~5 hours, post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)