### PR TITLE
docs: mention Calibrate placeholder tab in dashboard features

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -94,6 +94,7 @@ Opens at `http://127.0.0.1:8080` by default. Environment variables:
 
 **Features:**
 - **Research**: Persona, Institutional, Grading parameters via accordion panels
+- **Calibrate** *(skeleton)*: placeholder tab for upcoming OULAD-indexed calibration tooling (reference overlays, validation scorecard, Pareto viewer, HV convergence — landing in PR B/D)
 - **Engine Constants**: 70 advanced parameters in a slide-out panel
 - **Presets**: Default, High Risk, Low Dropout — one-click configuration
 - **Distributions**: 7 probability distributions with slider + numeric stepper, reactive sum validation (must equal 1.0)

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -94,7 +94,7 @@ Opens at `http://127.0.0.1:8080` by default. Environment variables:
 
 **Features:**
 - **Research**: Persona, Institutional, Grading parameters via accordion panels
-- **Calibrate** *(skeleton)*: placeholder tab for upcoming OULAD-indexed calibration tooling (reference overlays, validation scorecard, Pareto viewer, HV convergence — landing in PR B/D)
+- **Calibrate** *(skeleton)*: placeholder tab for upcoming OULAD-indexed calibration tooling — reference overlays, validation scorecard, Pareto viewer, and HV convergence
 - **Engine Constants**: 70 advanced parameters in a slide-out panel
 - **Presets**: Default, High Risk, Low Dropout — one-click configuration
 - **Distributions**: 7 probability distributions with slider + numeric stepper, reactive sum validation (must equal 1.0)


### PR DESCRIPTION
## Summary
- Follow-up to PR #79 (Research/Calibrate nav split) — GUIDE.md only had the Configure→Research rename. Adds a brief line documenting the new Calibrate placeholder tab and what's coming in PR B/D.

## Test plan
- [x] `python -m synthed.doc_facts` — All docs consistent
- [x] No code changes; pure docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)