### PR TITLE
fix: resolve flaky SSQ integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to SynthEd are documented here.
 
 ## [Unreleased]
 
+### Fixed
+- **Flaky `test_high_ssq_lower_dropout` / `test_low_ssq_higher_dropout`** (`tests/test_baulke_institutional.py`): the 3-seed × n=200 design gave a per-seed dropout std ≈0.0337 (SE ≈0.0195 across 3 seeds), so the 0.005 assertion threshold was ~0.26σ — well within seed variance. CI observed `diff=0.002` on Python 3.10, triggering fail-fast that also cancelled the 3.12 job. Raised seed count to 10 (seeds 41..50) and epsilon to 0.010 symmetrically for both directional tests; new SE ≈0.011 puts the threshold at ~0.9σ — still directional, no longer flaky. Full suite: 812 passed in 124s locally.
+
 ## [1.7.0] - 2026-04-18
 
 ### Changed

--- a/tests/test_baulke_institutional.py
+++ b/tests/test_baulke_institutional.py
@@ -245,20 +245,20 @@ class TestIntegrationDropoutRate:
         return _run
 
     def test_high_ssq_lower_dropout(self, _run_simulation):
-        """SSQ=0.8 should produce lower mean dropout than SSQ=0.5 (3 seeds, eps=0.005)."""
-        seeds = [41, 42, 43]
+        """SSQ=0.8 should produce lower mean dropout than SSQ=0.5 (10 seeds, eps=0.010)."""
+        seeds = list(range(41, 51))
         default_rate = sum(_run_simulation(0.5, seed=s) for s in seeds) / len(seeds)
         high_ssq_rate = sum(_run_simulation(0.8, seed=s) for s in seeds) / len(seeds)
-        assert high_ssq_rate <= default_rate - 0.005, (
+        assert high_ssq_rate <= default_rate - 0.010, (
             f"SSQ=0.8 mean dropout {high_ssq_rate:.3f} should be < default {default_rate:.3f}"
         )
 
     def test_low_ssq_higher_dropout(self, _run_simulation):
-        """SSQ=0.2 should produce higher mean dropout than SSQ=0.5 (3 seeds, eps=0.005)."""
-        seeds = [41, 42, 43]
+        """SSQ=0.2 should produce higher mean dropout than SSQ=0.5 (10 seeds, eps=0.010)."""
+        seeds = list(range(41, 51))
         default_rate = sum(_run_simulation(0.5, seed=s) for s in seeds) / len(seeds)
         low_ssq_rate = sum(_run_simulation(0.2, seed=s) for s in seeds) / len(seeds)
-        assert low_ssq_rate >= default_rate + 0.005, (
+        assert low_ssq_rate >= default_rate + 0.010, (
             f"SSQ=0.2 mean dropout {low_ssq_rate:.3f} should be > default {default_rate:.3f}"
         )
 

--- a/tests/test_baulke_institutional.py
+++ b/tests/test_baulke_institutional.py
@@ -245,7 +245,11 @@ class TestIntegrationDropoutRate:
         return _run
 
     def test_high_ssq_lower_dropout(self, _run_simulation):
-        """SSQ=0.8 should produce lower mean dropout than SSQ=0.5 (10 seeds, eps=0.010)."""
+        """SSQ=0.8 should produce lower mean dropout than SSQ=0.5 (10 seeds, eps=0.010).
+
+        Directional smoke test. Not a regression guard for true effect sizes
+        below ~0.015 — eps=0.010 is a pending empirical calibration (issue #86).
+        """
         seeds = list(range(41, 51))
         default_rate = sum(_run_simulation(0.5, seed=s) for s in seeds) / len(seeds)
         high_ssq_rate = sum(_run_simulation(0.8, seed=s) for s in seeds) / len(seeds)
@@ -254,7 +258,11 @@ class TestIntegrationDropoutRate:
         )
 
     def test_low_ssq_higher_dropout(self, _run_simulation):
-        """SSQ=0.2 should produce higher mean dropout than SSQ=0.5 (10 seeds, eps=0.010)."""
+        """SSQ=0.2 should produce higher mean dropout than SSQ=0.5 (10 seeds, eps=0.010).
+
+        Directional smoke test. Not a regression guard for true effect sizes
+        below ~0.015 — eps=0.010 is a pending empirical calibration (issue #86).
+        """
         seeds = list(range(41, 51))
         default_rate = sum(_run_simulation(0.5, seed=s) for s in seeds) / len(seeds)
         low_ssq_rate = sum(_run_simulation(0.2, seed=s) for s in seeds) / len(seeds)


### PR DESCRIPTION
## Summary
- Raise statistical power of `test_high_ssq_lower_dropout` and `test_low_ssq_higher_dropout` from 3 seeds/eps=0.005 to 10 seeds/eps=0.010
- Fixes PR #84 CI failure (`test (3.10)` fail → `test (3.12)` cancelled via fail-fast) that was unrelated to the changelog-only change there

## Root cause (statistical analysis)
- Per-seed dropout std ≈ √(0.35·0.65/200) ≈ **0.0337**
- 3-seed mean SE ≈ **0.0195**
- 0.005 threshold = **~0.26σ** — within seed noise
- CI observed: `SSQ=0.8 mean 0.348` vs `default 0.350` (diff=0.002) — miss by 0.003, threshold was fundamentally underpowered

## New design
- 10 seeds (41..50), eps=0.010 applied symmetrically to both directional tests
- SE ≈ **0.011**, threshold = **~0.9σ** — still directional signal, no longer flaky
- Runtime impact: ~3× for these 2 tests only (local: integration class 23.58s)

## Test plan
- [x] Local: `python -m pytest tests/test_baulke_institutional.py::TestIntegrationDropoutRate -q` → 3 passed
- [x] Local full suite: `python -m pytest tests/ -q` → 812 passed in 124s
- [x] Ruff: clean
- [ ] CI passes on all Python versions (3.10, 3.11, 3.12)
- [ ] Statistical consistency review (required per CLAUDE.md for validation-param changes)
- [ ] Python code review (required pre-merge)
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)